### PR TITLE
Handle and report errors of key source, do not write out key if keyCommand failed

### DIFF
--- a/src/nix/deployment.rs
+++ b/src/nix/deployment.rs
@@ -281,7 +281,7 @@ impl Deployment {
                         task.log("Uploading keys...");
 
                         if let Err(e) = target.host.upload_keys(&target.config.keys).await {
-                            task.failure(&format!("Failed to upload keys: {}", e));
+                            task.failure_err(&e);
 
                             let mut results = arc_self.results.lock().await;
                             let stage = Stage::Apply(node.to_string());
@@ -481,7 +481,7 @@ impl Deployment {
             bar.log("Uploading keys...");
 
             if let Err(e) = target.host.upload_keys(&target.config.keys).await {
-                bar.failure(&format!("Failed to upload keys: {}", e));
+                bar.failure_err(&e);
 
                 let mut results = self.results.lock().await;
                 let stage = Stage::Apply(name.to_string());

--- a/src/nix/host/ssh.rs
+++ b/src/nix/host/ssh.rs
@@ -211,10 +211,10 @@ impl Ssh {
         command.stderr(Stdio::piped());
         command.stdout(Stdio::piped());
 
-        let mut child = command.spawn()?;
-
-        let mut stdin = child.stdin.take().unwrap();
         let mut reader = key.reader().await?;
+
+        let mut child = command.spawn()?;
+        let mut stdin = child.stdin.take().unwrap();
         tokio::io::copy(reader.as_mut(), &mut stdin).await?;
         stdin.flush().await?;
         drop(stdin);

--- a/src/nix/mod.rs
+++ b/src/nix/mod.rs
@@ -59,6 +59,9 @@ pub enum NixError {
     #[snafu(display("Validation error"))]
     ValidationError { errors: ValidationErrors },
 
+    #[snafu(display("Failed to upload keys: {}", error))]
+    KeyError { error: key::KeyError },
+
     #[snafu(display("Invalid NixOS system profile"))]
     InvalidProfile,
 
@@ -69,6 +72,12 @@ pub enum NixError {
 impl From<std::io::Error> for NixError {
     fn from(error: std::io::Error) -> Self {
         Self::IoError { error }
+    }
+}
+
+impl From<key::KeyError> for NixError {
+    fn from(error: key::KeyError) -> Self {
+        Self::KeyError { error }
     }
 }
 

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -224,6 +224,10 @@ impl TaskProgress {
         }
     }
 
+    pub fn failure_err<E: std::error::Error>(self, error: &E) {
+        self.failure(&error.to_string())
+    }
+
     fn plain_print(&self, style: Style, line: &str) {
         eprintln!("{:>width$} | {}", style.apply_to(&self.label), line, width = self.label_width);
     }


### PR DESCRIPTION
So I thought that it might be nice to log out a proper error if `keyCommand` fails. I also made it so the output is buffered. This way, the key is not partially written if the `keyCommand` fails in the middle. So there is no possibility to clobber an existing key with a malformed one.

Example output (non-existent `keyFile`):
![Screenshot from 2021-02-11 21-06-39](https://user-images.githubusercontent.com/662666/107686034-6257df00-6cad-11eb-9acc-1615575ae51c.png)

Example output (`keyCommand = ["date" "-Ins" "foobar"]` (extraneous argument to the `date` command)):
![Screenshot from 2021-02-11 21-06-53](https://user-images.githubusercontent.com/662666/107686037-63890c00-6cad-11eb-8d5d-16f7ec9a8f4a.png)

If stderr contains multiple lines, it does not print out nicely, especially with the progress bar mode. Not sure how to deal with that.
