### PR TITLE
Propagate same 'pkgs' to all modules

### DIFF
--- a/src/nix/eval.nix
+++ b/src/nix/eval.nix
@@ -253,6 +253,7 @@ let
     specialArgs = {
       inherit name nodes;
       modulesPath = npkgs.path + "/nixos/modules";
+      pkgs = npkgs;
     };
   };
 


### PR DESCRIPTION
This one is kinda hard to explain because nixpkgs internals are still a bit of a mystery to me.

Given a hive that looks something like this:

```nix
let
  pkgs = builtins.fetchGit {
    name = "nixos-20.09-2021-01-27";
    url = "https://github.com/nixos/nixpkgs";
    ref = "refs/heads/nixos-20.09-small";
    rev = "02a184883e423ff2da75581518d3ed2efeb8577d";
  };
in
{
  network = {
    nixpkgs = import pkgs {
      config.allowUnfree = true;
    };
  };

  machine = { ... }: { /* ... */ };
}
```

Colmena (or rather Nix) would give me errors:
```
Evaluation of 2 nodes failed. Last 10 lines of logs:
a) For `nixos-rebuild` you can set
  { nixpkgs.config.allowUnfree = true; }
in configuration.nix to override this.

b) For `nix-env`, `nix-build`, `nix-shell` or any other Nix command you can add
  { allowUnfree = true; }
to ~/.config/nixpkgs/config.nix.

(use '--show-trace' to show detailed location information)
```

But I am obviously allowing unfree packages!

Turns out the given nixpkgs (instantiated with the wanted config), is not automatically passed as the parameter `pkgs` to inner modules. Morph solves this [by setting `nixpkgs.pkgs`](https://github.com/DBCDK/morph/blob/c048d6339f18613a1544bc62ff852cb4c6de1042/data/eval-machines.nix#L38-L39), but I had more success with the approach in this PR.

The [documentation of `nixpkgs.pkgs` option](https://search.nixos.org/options?channel=20.09&show=nixpkgs.pkgs&from=0&size=50&sort=relevance&query=nixpkgs.pkgs) explains it better perhaps.

Not tested thoroughly, but at least my machines seem to build successfully with this, both `allowUnfree = true;` and `system = "aarch64-linux";` are respected.