### PR TITLE
Warn on unknown remote profiles replacement, error out if node-level option is explicitly enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,16 @@ Here is a sample `hive.nix` with two nodes, with some common configurations appl
     environment.systemPackages = with pkgs; [
       vim wget curl
     ];
+
+    # By default, Colmena will replace unknown remote profile
+    # (unknown means the profile isn't in the nix store on the
+    # host running Colmena) during apply (with the default goal,
+    # boot, and switch).
+    # If you share a hive with others, or use multiple machines,
+    # and are not careful to always commit/push/pull changes
+    # you can accidentaly overwrite a remote profile so in those
+    # scenarios you might want to change this default to false. 
+    # deployment.replaceUnknownProfiles = true;
   };
 
   host-a = { name, nodes, ... }: {
@@ -86,6 +96,9 @@ Here is a sample `hive.nix` with two nodes, with some common configurations appl
     # For further customization, use the SSH_CONFIG_FILE
     # environment variable to specify a ssh_config file.
     deployment.targetPort = 1234;
+
+    # Override the default for this target host
+    deployment.replaceUnknownProfiles = false;
 
     time.timeZone = "America/Los_Angeles";
 

--- a/src/command/apply.rs
+++ b/src/command/apply.rs
@@ -91,6 +91,12 @@ To upload keys without building or deploying the rest of the configuration, use 
             .help("Do not use gzip")
             .long_help("Disables the use of gzip when copying closures to the remote host.")
             .takes_value(false))
+        .arg(Arg::with_name("force-replace-unknown-profiles")
+            .long("force-replace-unknown-profiles")
+            .help("Ignore all targeted nodes deployment.replaceUnknownProfiles setting")
+            .long_help(r#"If `deployment.replaceUnknownProfiles` is set for a target, using this switch
+will treat deployment.replaceUnknownProfiles as though it was set true and perform unknown profile replacement."#)
+            .takes_value(false))
 }
 
 pub fn subcommand() -> App<'static, 'static> {
@@ -186,6 +192,7 @@ pub async fn run(_global_args: &ArgMatches<'_>, local_args: &ArgMatches<'_>) {
     options.set_gzip(!local_args.is_present("no-gzip"));
     options.set_progress_bar(!local_args.is_present("verbose"));
     options.set_upload_keys(!local_args.is_present("no-keys"));
+    options.set_force_replace_unknown_profiles(local_args.is_present("force-replace-unknown-profiles"));
 
     if local_args.is_present("keep-result") {
         options.set_gc_roots(hive_base.join(".gcroots"));

--- a/src/nix/eval.nix
+++ b/src/nix/eval.nix
@@ -120,6 +120,22 @@ let
           type = types.attrsOf keyType;
           default = {};
         };
+        replaceUnknownProfiles = lib.mkOption {
+          description = ''
+            Allow a configuration to be applied to a host running a profile we
+            have no knowledge of. By setting this option to false, you reduce
+            the likelyhood of rolling back changes made via another Colmena user.
+
+            Unknown profiles are usually the result of either:
+            - The node had a profile applied, locally or by another Colmena.
+            - The host running Colmena garbage-collecting the profile.
+
+            To force profile replacement on all targeted nodes during apply,
+            use the flag `--force-replace-unknown-profiles`.
+          '';
+          type = types.bool;
+          default = true;
+        };
       };
     };
   };

--- a/src/nix/host/local.rs
+++ b/src/nix/host/local.rs
@@ -92,6 +92,9 @@ impl Host for Local {
 
         result
     }
+    async fn active_derivation_known(&mut self) -> NixResult<bool> {
+        Ok(true)
+    }
     fn set_progress_bar(&mut self, bar: TaskProgress) {
         self.progress_bar = bar;
     }

--- a/src/nix/host/mod.rs
+++ b/src/nix/host/mod.rs
@@ -102,7 +102,10 @@ pub trait Host: Send + Sync + std::fmt::Debug {
         Err(NixError::Unsupported)
     }
 
-    #[allow(unused_variables)] 
+    /// Check if the active profile is known to the host running Colmena
+    async fn active_derivation_known(&mut self) -> NixResult<bool>;
+
+    #[allow(unused_variables)]
     /// Activates a system profile on the host, if it runs NixOS.
     ///
     /// The profile must already exist on the host. You should probably use deploy instead.

--- a/src/nix/mod.rs
+++ b/src/nix/mod.rs
@@ -68,6 +68,9 @@ pub enum NixError {
     #[snafu(display("Invalid NixOS system profile"))]
     InvalidProfile,
 
+    #[snafu(display("Unknown active profile: {}", store_path))]
+    ActiveProfileUnknown { store_path: String },
+
     #[snafu(display("Nix Error: {}", message))]
     Unknown { message: String },
 }
@@ -104,6 +107,9 @@ pub struct NodeConfig {
     #[serde(rename = "allowLocalDeployment")]
     allow_local_deployment: bool,
     tags: Vec<String>,
+
+    #[serde(rename = "replaceUnknownProfiles")]
+    replace_unknown_profiles: bool,
 
     #[validate(custom = "validate_keys")]
     keys: HashMap<String, Key>,


### PR DESCRIPTION
Adds a `deployment.replaceUnknownProfiles` option and `--ignore-replace-unknown-profiles` option flag to the cli

If `deployment.replaceUnknownProfiles` is set to false, a diverged hive config (in a shared git repo for example) won't result in accidentally undoing another applied configuration profile. Just moving back and forth between my desktop and laptop I managed to replace a profile because I forgot to commit and push changes on one machine.

The deployment option `deployment.replaceUnknownProfiles` default is true so that fiction is minimized from aggressive nix store garbage collection, first time profile application, etc. If a hive is being modified across a large team, it's probably best to just use CI/CD, so this option mostly exists for single user and small teams who might otherwise unknowingly overwrite others changes.

Since this only checks the local nix store, it's certainly not infallible, but alternative ideas like keeping a profile log that would be committed to the repo introduce additional complexities like an ever-growing log, potential merge conflicts, assumptions about VCS, etc.

My knowledge of Rust is as deep as "emulate what I see in other places", so if there is a more idiomatic way to implement a particular section of code I can attempt to make changes.

No worries if this isn't something you're interested in merging, it was mostly to solve a problem I had and to learn a bit more Rust along the way.