### PR TITLE
eval.nix: Adds meta.machinesFile option that is passed to Nix as builder option

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,15 @@ Here is a sample `hive.nix` with two nodes, with some common configurations appl
     nodeNixpkgs = {
       node-b = ./another-nixos-checkout;
     };
+
+    # If your Colmena host has nix configured to allow for remote builds
+    # (for nix-daemon, your user being included in trusted-users)
+    # you can set a machines file that will be passed to the underlying
+    # nix-store command during derivation realization as a builders option.
+    # For example, if you support multiple orginizations each with their own
+    # build machine(s) you can ensure that builds only take place on your
+    # local machine and/or the machines specified in this file.
+    # machinesFile = ./machines.client-a;
   };
 
   defaults = { pkgs, ... }: {

--- a/src/command/apply.rs
+++ b/src/command/apply.rs
@@ -115,6 +115,8 @@ pub async fn run(_global_args: &ArgMatches<'_>, local_args: &ArgMatches<'_>) {
     log::info!("Enumerating nodes...");
     let all_nodes = hive.deployment_info().await.unwrap();
 
+    let nix_options = hive.nix_options().await.unwrap();
+
     let selected_nodes = match local_args.value_of("on") {
         Some(filter) => {
             util::filter_nodes(&all_nodes, filter)
@@ -159,7 +161,7 @@ pub async fn run(_global_args: &ArgMatches<'_>, local_args: &ArgMatches<'_>) {
                 if build_only {
                     targets.insert(
                         node.clone(),
-                        Target::new(localhost(), config.clone()),
+                        Target::new(localhost(nix_options.clone()), config.clone()),
                     );
                 }
             }

--- a/src/command/apply_local.rs
+++ b/src/command/apply_local.rs
@@ -100,13 +100,14 @@ pub async fn run(_global_args: &ArgMatches<'_>, local_args: &ArgMatches<'_>) {
 
     let target: Target = {
         if let Some(info) = hive.deployment_info_for(&hostname).await.unwrap() {
+            let nix_options = hive.nix_options().await.unwrap();
             if !info.allows_local_deployment() {
                 log::error!("Local deployment is not enabled for host {}.", hostname);
                 log::error!("Hint: Set deployment.allowLocalDeployment to true.");
                 quit::with_code(2);
             }
             Target::new(
-                host::local(),
+                host::local(nix_options),
                 info.clone(),
             )
         } else {

--- a/src/nix/deployment.rs
+++ b/src/nix/deployment.rs
@@ -460,8 +460,9 @@ impl Deployment {
     }
 
     async fn build_profiles(self: Arc<Self>, chunk: &Vec<String>, derivation: StoreDerivation<ProfileMap>, progress: TaskProgress) -> Option<ProfileMap> {
+        let nix_options = self.hive.nix_options().await.unwrap();
         // FIXME: Remote build?
-        let mut builder = host::local();
+        let mut builder = host::local(nix_options);
 
         builder.set_progress_bar(progress.clone());
 

--- a/src/nix/eval.nix
+++ b/src/nix/eval.nix
@@ -48,6 +48,25 @@ let
         type = types.attrsOf types.unspecified;
         default = {};
       };
+      machinesFile = lib.mkOption {
+        description = ''
+          Use the machines listed in this file when building this hive configuration.
+
+          If your Colmena host has nix configured to allow for remote builds
+          (for nix-daemon, your user being included in trusted-users)
+          you can set a machines file that will be passed to the underlying
+          nix-store command during derivation realization as a builders option.
+          For example, if you support multiple orginizations each with their own
+          build machine(s) you can ensure that builds only take place on your
+          local machine and/or the machines specified in this file.
+
+          See https://nixos.org/manual/nix/stable/#chap-distributed-builds
+          for the machine specification format.
+        '';
+        default = null;
+        apply = value: if value == null then null else toString value;
+        type = types.nullOr types.path;
+      };
     };
   };
 
@@ -311,4 +330,5 @@ let
   };
 in {
   inherit nodes deploymentConfigJson toplevel buildAll buildSelected introspect;
+  meta = hive.meta;
 }

--- a/src/nix/host/local.rs
+++ b/src/nix/host/local.rs
@@ -18,13 +18,15 @@ use crate::progress::TaskProgress;
 pub struct Local {
     progress_bar: TaskProgress,
     logs: String,
+    nix_options: Vec<String>,
 }
 
 impl Local {
-    pub fn new() -> Self {
+    pub fn new(nix_options: Vec<String>) -> Self {
         Self {
             progress_bar: TaskProgress::default(),
             logs: String::new(),
+            nix_options,
         }
     }
 }
@@ -36,6 +38,8 @@ impl Host for Local {
     }
     async fn realize_remote(&mut self, derivation: &StorePath) -> NixResult<Vec<StorePath>> {
         let mut command = Command::new("nix-store");
+
+        command.args(self.nix_options.clone());
         command
             .arg("--no-gc-warning")
             .arg("--realise")

--- a/src/nix/host/mod.rs
+++ b/src/nix/host/mod.rs
@@ -13,8 +13,8 @@ pub use local::Local;
 
 mod key_uploader;
 
-pub(crate) fn local() -> Box<dyn Host + 'static> {
-    Box::new(Local::new())
+pub(crate) fn local(nix_options: Vec<String>) -> Box<dyn Host + 'static> {
+    Box::new(Local::new(nix_options))
 }
 
 #[derive(Copy, Clone, Debug)]


### PR DESCRIPTION
While Colmena works with remote builders if the local host is configured for it (in my case the multi-user nix-daemon on macOS), I'm needing to build multiple hives on different sets of builders without cross-contamination of the builders nix store. Local contamination is fine, but the remote builders are going to be configured to sign and push to different binary caches so I want to keep them separate.

This PR only modifies the host::local builder to support the nix options, so when/if a purely remote builder is implemented it might require some updates.

One alternative idea I tried was to override the requiredSystemFeatures attribute on the evaluated node in eval.nix, but that only resulted in the final system derivation being forced to use a matching machine and the input derivations seemed free to build elsewhere.

As stated in my unknown-profiles PR, I'm still learning idiomatic Rust so I'm not sure when it's best to use a setter vs constructor args, but based on how host::local was used, it seemed cleaner to use constructor args. Especially as I'm still stumbling around the async/sync parts of Rust. The rust compiler and I spent a lot of time going in circles with future-related errors, so just because it compiles and works now doesn't mean it can't be done much cleaner/better, lol.

Again, no worries if this isn't something you're interested in merging. It solves my particular issue well enough for now but figured it might be useful to someone else along the way.