### PR TITLE
Allow selecting ssh user dynamically

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -133,6 +133,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tokio-test",
+ "users",
  "validator",
 ]
 
@@ -888,6 +889,16 @@ dependencies = [
  "idna",
  "matches",
  "percent-encoding",
+]
+
+[[package]]
+name = "users"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24cc0f6d6f267b73e5a2cadf007ba8f9bc39c6a6f9666f8cf25ea809a153b032"
+dependencies = [
+ "libc",
+ "log",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ sys-info = "0.7.0"
 snafu = "0.6.10"
 tempfile = "3.1.0"
 tokio-test = "0.4.0"
+users = "0.11.0"
 validator = { version = "0.12", features = ["derive"] }
 
 [dependencies.tokio]

--- a/src/nix/eval.nix
+++ b/src/nix/eval.nix
@@ -113,9 +113,10 @@ let
         };
         targetUser = lib.mkOption {
           description = ''
-            The user to use to log into the remote node.
+            The user to use to log into the remote node. If null, login as the
+            current user.
           '';
-          type = types.str;
+          type = types.nullOr types.str;
           default = "root";
         };
         allowLocalDeployment = lib.mkOption {

--- a/src/nix/tests/mod.rs
+++ b/src/nix/tests/mod.rs
@@ -134,7 +134,7 @@ fn test_parse_simple() {
     ));
     assert_eq!(Some("host-a"), nodes["host-a"].target_host.as_deref());
     assert_eq!(None, nodes["host-a"].target_port);
-    assert_eq!("root", &nodes["host-a"].target_user);
+    assert_eq!(Some("root"), nodes["host-a"].target_user.as_deref());
 
     // host-b
     assert!(set_eq(
@@ -143,7 +143,7 @@ fn test_parse_simple() {
     ));
     assert_eq!(Some("somehost.tld"), nodes["host-b"].target_host.as_deref());
     assert_eq!(Some(1234), nodes["host-b"].target_port);
-    assert_eq!("luser", &nodes["host-b"].target_user);
+    assert_eq!(Some("luser"), nodes["host-b"].target_user.as_deref());
 }
 
 #[test]


### PR DESCRIPTION
...by setting `deployment.targetUser = null`.

This allows sharing a deployment file (hive.nix/flake.nix) between
multiple admins, without having to use a shared root account.