### PR TITLE
eval.nix: expose nixosModules.deploymentOptions

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -13,8 +13,12 @@
 
   outputs = { self, nixpkgs, utils, ... }: let
     supportedSystems = [ "x86_64-linux" "i686-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
+    evalNix = import ./src/nix/hive/eval.nix {
+      hermetic = true;
+    };
   in utils.lib.eachSystem supportedSystems (system: let
     pkgs = import nixpkgs { inherit system; };
+
   in rec {
     # We still maintain the expression in a Nixpkgs-acceptable form
     defaultPackage = self.packages.${system}.colmena;
@@ -24,9 +28,6 @@
       # Full user manual
       manual = let
         colmena = self.packages.${system}.colmena;
-        evalNix = import ./src/nix/hive/eval.nix {
-          hermetic = true;
-        };
         deploymentOptionsMd = (pkgs.nixosOptionsDoc {
           options = evalNix.docs.deploymentOptions pkgs;
         }).optionsCommonMark;
@@ -61,5 +62,6 @@
     overlay = final: prev: {
       colmena = final.callPackage ./package.nix { };
     };
+    inherit (evalNix) nixosModules;
   };
 }

--- a/src/nix/hive/eval.nix
+++ b/src/nix/hive/eval.nix
@@ -524,6 +524,8 @@ in {
 
   meta = hive.meta;
 
+  nixosModules = { inherit deploymentOptions; };
+
   docs = {
     deploymentOptions = pkgs: let
       eval = pkgs.lib.evalModules {


### PR DESCRIPTION
Allow flake users to import .#nixosModules.deploymentOptions
into their flake, so that the same expression can be used for both,
.#colmena.$host as well as .#nixosConfigurations.$host, without the
latter complaining about undefined options in "deployment".

Tests seem to pass, building the manual still works and the resulting nixosModules.deploymentOptions works as expected in my configration. What do you think?

(reusing the same attrset for nixosConfigurations and colmena hosts only really works for setups which don't use the name and nodes parameters)