### PR TITLE
eval.nix: Add "${name}-key.service" units for keys

### DIFF
--- a/integration-tests/apply/test-script.py
+++ b/integration-tests/apply/test-script.py
@@ -68,6 +68,15 @@ with subtest("Check that key files have correct permissions"):
         for path, permission in permissions.items():
             node.succeed(f"if [[ \"{permission}\" != \"$(stat -c '%a %U %G' '{path}')\" ]]; then ls -lah '{path}'; exit 1; fi")
 
+with subtest("Check that key services respond to key file changes"):
+    alpha.require_unit_state("key-text-key.service", "active")
+
+    alpha.succeed("rm /run/keys/key-text")
+    alpha.wait_until_succeeds("systemctl --no-pager show key-text-key.service | grep ActiveState=inactive", timeout=10)
+
+    alpha.succeed("touch /run/keys/key-text")
+    alpha.wait_for_unit("key-text-key.service")
+
 with subtest("Check that we can correctly deploy to remaining nodes despite failures"):
     beta.systemctl("stop sshd")
 

--- a/integration-tests/tools.nix
+++ b/integration-tests/tools.nix
@@ -62,6 +62,7 @@ let
 
       environment.systemPackages = with pkgs; [
         git # for git flake tests
+        inotifyTools # for key services build
 
         # HACK: copy stderr to both stdout and stderr
         # (the test framework only captures stdout, and only stderr appears on screen during the build)

--- a/manual/src/features/keys.md
+++ b/manual/src/features/keys.md
@@ -28,3 +28,8 @@ For example, to deploy DNS-01 credentials for use with `security.acme`:
 
 Take note that if you use the default path (`/run/keys`), the secret files are only stored in-memory and will not survive reboots.
 To upload your secrets without performing a full deployment, use `colmena upload-keys`.
+
+## Key Services
+
+For each secret file deployed using `deployment.keys`, a systemd service with the name of `${name}-key.service` is created (`acme-credentials.secret-key.service` for the example above).
+This unit is only active when the corresponding file is present, allowing you to set up dependencies for services requiring secret files to function.


### PR DESCRIPTION
Fixes #48.