### PR TITLE
apply_local: Fix nixos detection from os-release

### DIFF
--- a/src/command/apply_local.rs
+++ b/src/command/apply_local.rs
@@ -1,4 +1,5 @@
 use std::env;
+use regex::Regex;
 use std::collections::HashMap;
 
 use clap::{Arg, App, ArgMatches};
@@ -61,7 +62,8 @@ By default, Colmena will deploy keys set in `deployment.keys` before activating 
 pub async fn run(_global_args: &ArgMatches, local_args: &ArgMatches) -> Result<(), ColmenaError> {
     // Sanity check: Are we running NixOS?
     if let Ok(os_release) = fs::read_to_string("/etc/os-release").await {
-        if !os_release.contains("ID=nixos\n") {
+        let re = Regex::new(r#"ID="?nixos"?"#).unwrap();
+        if !re.is_match(&os_release) {
             log::error!("\"apply-local\" only works on NixOS machines.");
             quit::with_code(5);
         }


### PR DESCRIPTION
This fixes apply-local not detecting the system as NixOS due to the changes in the format of the `os-release` file.

Details on the changes made to the `os-release` file can be found in the following commit https://github.com/NixOS/nixpkgs/commit/bae181d3f0f453d9a23cf5e899c2cb0f96e91fef.

I'm new to Rust so let me know if I've missed anything, thanks!