### PR TITLE
Use new Nix for CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,14 +10,8 @@ jobs:
           - ubuntu-latest
           - macos-11
         nix:
-          #- name: 2.3.16
-          #  url: https://releases.nixos.org/nix/nix-2.3.16/install
-          #- name: 2.4
-          #  url: https://releases.nixos.org/nix/nix-2.4/install
           - name: 2.7.0
             url: https://releases.nixos.org/nix/nix-2.7.0/install
-          #- name: 2.8.0pre
-          #  url: https://github.com/numtide/nix-unstable-installer/releases/download/nix-2.8.0pre20220314_a618097/install
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2.3.5

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2.3.5
-      - uses: cachix/install-nix-action@v15
+      - uses: cachix/install-nix-action@v17
         with:
           install_url: ${{ matrix.nix.url }}
           extra_nix_config: |
@@ -56,7 +56,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2.3.5
-      - uses: cachix/install-nix-action@v15
+      - uses: cachix/install-nix-action@v17
         with:
           install_url: ${{ matrix.nix.url }}
           extra_nix_config: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,8 +10,8 @@ jobs:
           - ubuntu-latest
           - macos-11
         nix:
-          - name: 2.7.0
-            url: https://releases.nixos.org/nix/nix-2.7.0/install
+          - name: 2.8.0
+            url: https://releases.nixos.org/nix/nix-2.8.0/install
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2.3.5
@@ -51,10 +51,8 @@ jobs:
             url: https://releases.nixos.org/nix/nix-2.3.16/install
           - name: 2.4
             url: https://releases.nixos.org/nix/nix-2.4/install
-          - name: 2.7.0
-            url: https://releases.nixos.org/nix/nix-2.7.0/install
-          - name: 2.8.0pre
-            url: https://github.com/numtide/nix-unstable-installer/releases/download/nix-2.8.0pre20220314_a618097/install
+          - name: 2.8.0
+            url: https://releases.nixos.org/nix/nix-2.8.0/install
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2.3.5

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "flake-compat": {
       "flake": false,
       "locked": {
-        "lastModified": 1648199409,
-        "narHash": "sha256-JwPKdC2PoVBkG6E+eWw3j6BMR6sL3COpYWfif7RVb8Y=",
+        "lastModified": 1650374568,
+        "narHash": "sha256-Z+s0J8/r907g149rllvwhb4pKi8Wam5ij0st8PwAh+E=",
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "64a525ee38886ab9028e6f61790de0832aa3ef03",
+        "rev": "b4a34015c698c7793d592d66adbab377907a2be8",
         "type": "github"
       },
       "original": {
@@ -18,11 +18,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1648632716,
-        "narHash": "sha256-kCmnDeiaMsdhfnNKjxdOzwRh2H6eQb8yWAL+nNabC/Y=",
+        "lastModified": 1650831523,
+        "narHash": "sha256-6pDZ08SAXsUx5rOP391x+TG39ENP/XA8VMa1tQvgEjc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "710fed5a2483f945b14f4a58af2cd3676b42d8c8",
+        "rev": "87d34a6b8982e901b8e50096b8e79ebc0e66cda0",
         "type": "github"
       },
       "original": {
@@ -42,11 +42,11 @@
     },
     "stable": {
       "locked": {
-        "lastModified": 1648965846,
-        "narHash": "sha256-xaO0KS+sgZLYrhaQNjVe6eRcOUIM1mEkAjT+dRbPblU=",
+        "lastModified": 1650830814,
+        "narHash": "sha256-P7vGsHdS19eHVUJt4BeQA4JfauL2nOpEcnYKIbX76YM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0aac710801aec4ba545527cf41a5706028fe6271",
+        "rev": "c254b8c915ac912ae9ee9dc74eac555ccbf33795",
         "type": "github"
       },
       "original": {
@@ -58,11 +58,11 @@
     },
     "utils": {
       "locked": {
-        "lastModified": 1648297722,
-        "narHash": "sha256-W+qlPsiZd8F3XkzXOzAoR+mpFqzm3ekQkJNa+PIh1BQ=",
+        "lastModified": 1649676176,
+        "narHash": "sha256-OWKJratjt2RW151VUlJPRALb7OU2S5s+f0vLj4o1bHM=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "0f8662f1319ad6abf89b3380dd2722369fc51ade",
+        "rev": "a4b154ebbdc88c8498a5c7b01589addc9e9cb678",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
- ci: remove unused Nix versions in build stage
- ci: upgrade to Nix 2.8.0 for build and test
- ci: update cachix/install-nix-action to v17
