### PR TITLE
Do not use an explicit user for ssh when deploymentUser is null

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -162,7 +162,6 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tokio-test",
- "users",
  "uuid",
  "validator",
 ]
@@ -984,16 +983,6 @@ dependencies = [
  "idna",
  "matches",
  "percent-encoding",
-]
-
-[[package]]
-name = "users"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24cc0f6d6f267b73e5a2cadf007ba8f9bc39c6a6f9666f8cf25ea809a153b032"
-dependencies = [
- "libc",
- "log",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,6 @@ sys-info = "0.9.0"
 snafu = "0.7.0"
 tempfile = "3.1.0"
 tokio-stream = "0.1.8"
-users = "0.11.0"
 uuid = { version = "1.0.0", features = ["serde", "v4"] }
 validator = { version = "0.15.0", features = ["derive"] }
 

--- a/package.nix
+++ b/package.nix
@@ -9,7 +9,9 @@ rustPlatform.buildRustPackage rec {
     src = lib.cleanSource ./.;
   };
 
-  cargoSha256 = "sha256-GxWhzDx3hK7ONtLINYz0Ssw4DL+BNX6uH0JoQuooCCU=";
+  cargoLock = {
+    lockFile = ./Cargo.lock;
+  };
 
   nativeBuildInputs = [ installShellFiles ];
 

--- a/src/nix/host/ssh.rs
+++ b/src/nix/host/ssh.rs
@@ -18,7 +18,7 @@ use super::{CopyDirection, CopyOptions, RebootOptions, Host, key_uploader};
 #[derive(Debug)]
 pub struct Ssh {
     /// The username to use to connect.
-    user: String,
+    user: Option<String>,
 
     /// The hostname or IP address to connect to.
     host: String,
@@ -166,7 +166,7 @@ impl Host for Ssh {
 }
 
 impl Ssh {
-    pub fn new(user: String, host: String) -> Self {
+    pub fn new(user: Option<String>, host: String) -> Self {
         Self {
             user,
             host,
@@ -197,7 +197,7 @@ impl Ssh {
     pub fn ssh(&self, command: &[&str]) -> Command {
         let options = self.ssh_options();
         let options_str = options.join(" ");
-        let privilege_escalation_command = if self.user != "root" {
+        let privilege_escalation_command = if self.user.as_deref() != Some("root") {
             self.privilege_escalation_command.as_slice()
         } else {
             &[]
@@ -224,7 +224,10 @@ impl Ssh {
     }
 
     fn ssh_target(&self) -> String {
-        format!("{}@{}", self.user, self.host)
+        match &self.user {
+            Some(n) => format!("{}@{}", n, self.host),
+            None => self.host.clone(),
+        }
     }
 
     fn nix_copy_closure(&self, path: &StorePath, direction: CopyDirection, options: CopyOptions) -> Command {

--- a/src/nix/mod.rs
+++ b/src/nix/mod.rs
@@ -5,7 +5,6 @@ use std::path::Path;
 
 use serde::de;
 use serde::{Deserialize, Deserializer, Serialize};
-use users::get_current_username;
 use validator::{Validate, ValidationError as ValidationErrorType};
 
 use crate::error::{ColmenaResult, ColmenaError};
@@ -164,12 +163,7 @@ impl NodeConfig {
 
     pub fn to_ssh_host(&self) -> Option<Ssh> {
         self.target_host.as_ref().map(|target_host| {
-            let username =
-                match &self.target_user {
-                    Some(uname) => uname.clone(),
-                    None => get_current_username().unwrap().into_string().unwrap(),
-                };
-            let mut host = Ssh::new(username, target_host.clone());
+            let mut host = Ssh::new(self.target_user.clone(), target_host.clone());
             host.set_privilege_escalation_command(self.privilege_escalation_command.clone());
 
             if let Some(target_port) = self.target_port {


### PR DESCRIPTION
Right now colmena will statically emit the current user in the `user@host` target, preventing the usage of .ssh/config or equivalent of overriding the username.

In situations where a repository is shared with multiple people such that configuring deploymentUser in the repository is unfeasible, this makes it easier when certain remote machines demand a particular user that is different from the local user.


This also addresses #61 