### PR TITLE
eval.nix: per-node specialArgs

### DIFF
--- a/src/nix/hive/eval.nix
+++ b/src/nix/hive/eval.nix
@@ -146,7 +146,7 @@ let
       colmenaOptions.deploymentOptions
       hive.defaults
     ] ++ configs;
-    specialArgs = hive.meta.specialArgs // {
+    specialArgs = hive.meta.specialArgs // (hive.meta.nodeSpecialArgs.${name} or {}) // {
       inherit name;
       nodes = uncheckedNodes;
     };

--- a/src/nix/hive/options.nix
+++ b/src/nix/hive/options.nix
@@ -248,6 +248,13 @@ with builtins; rec {
         type = types.attrsOf types.unspecified;
         default = {};
       };
+      nodeSpecialArgs = lib.mkOption {
+        description = ''
+          Node-specific special args.
+        '';
+        type = types.attrsOf types.unspecified;
+        default = {};
+      };
       machinesFile = lib.mkOption {
         description = ''
           Use the machines listed in this file when building this hive configuration.


### PR DESCRIPTION
This adds `meta.nodeSpecialArgs` which follows the same semantics as `meta.nodeNixpkgs` but for the `specialArgs` passed into evaluation.