### PR TITLE
Support NixOS containers as targets

### DIFF
--- a/src/nix/hive/options.nix
+++ b/src/nix/hive/options.nix
@@ -124,6 +124,14 @@ with builtins; rec {
           type = types.nullOr types.str;
           default = "root";
         };
+        targetContainer = lib.mkOption {
+          description = ''
+            If set to a string, Colmena will update a container on the
+            target host instead of updating the target host itself.
+          '';
+          type = types.nullOr types.str;
+          default = null;
+        };
         allowLocalDeployment = lib.mkOption {
           description = ''
             Allow the configuration to be applied locally on the host running

--- a/src/nix/mod.rs
+++ b/src/nix/mod.rs
@@ -64,6 +64,9 @@ pub struct NodeConfig {
     #[serde(rename = "targetPort")]
     target_port: Option<u16>,
 
+    #[serde(rename = "targetContainer")]
+    target_container: Option<String>,
+
     #[serde(rename = "allowLocalDeployment")]
     allow_local_deployment: bool,
 
@@ -174,7 +177,11 @@ impl NodeConfig {
 
     pub fn to_ssh_host(&self) -> Option<Ssh> {
         self.target_host.as_ref().map(|target_host| {
-            let mut host = Ssh::new(self.target_user.clone(), target_host.clone());
+            let mut host = Ssh::new(
+                self.target_user.clone(),
+                target_host.clone(),
+                self.target_container.clone()
+            );
             host.set_privilege_escalation_command(self.privilege_escalation_command.clone());
 
             if let Some(target_port) = self.target_port {

--- a/src/nix/node_filter.rs
+++ b/src/nix/node_filter.rs
@@ -207,6 +207,7 @@ mod tests {
             target_host: None,
             target_user: None,
             target_port: None,
+            target_container: None,
             allow_local_deployment: false,
             build_on_target: false,
             replace_unknown_profiles: false,


### PR DESCRIPTION
This adds support for applying a configuration to a NixOS container.

Note, this requires the respective container to already exist and be started. 

---

Example:

Hive configuration (partial):

```nix
{
  # ...

  "test" = _: {
    deployment = {
      targetHost = "example.com";
      targetContainer = "test";
      buildOnTarget = true;
    };

    boot.isContainer = true;

    system = {
      stateVersion = "22.11";

      configurationRevision = "hello-world";
    };
  };
}
```

Apply the configuration:

```
λ colmena apply --on test
[INFO ] Using flake: git+file:///path/to/flake
[INFO ] Enumerating nodes...
[INFO ] Selected 1 out of 2 hosts.
      ✅ 7s All done!
 test ✅ 3s Evaluated test
 test ✅ 2s Built "/nix/store/n46xpmzlqvz76bnyl4dlfm26a20qhss1-nixos-system-nixos-22.11pre-git" on target node
 test ✅ 2s Activation successful
```

Verify:

```
[root@example.com:~]# nixos-container run test -- nixos-version --json
{"configurationRevision":"hello-world","nixosVersion":"22.11pre-git"}
```