### PR TITLE
Don't bind key services to key path units

### DIFF
--- a/src/nix/hive/modules.nix
+++ b/src/nix/hive/modules.nix
@@ -78,7 +78,6 @@ with builtins; {
       systemd.services = lib.mapAttrs' (name: val: {
         name = "${name}-key";
         value = {
-          bindsTo = [ "${name}-key.path" ];
           serviceConfig = {
             Restart = "on-failure";
           };


### PR DESCRIPTION
Removes binding from key service to key paths as per #116 