### PR TITLE
Use nixops implementation of key services

### DIFF
--- a/integration-tests/apply/test-script.py
+++ b/integration-tests/apply/test-script.py
@@ -68,11 +68,14 @@ with subtest("Check that key files have correct permissions"):
         for path, permission in permissions.items():
             node.succeed(f"if [[ \"{permission}\" != \"$(stat -c '%a %U %G' '{path}')\" ]]; then ls -lah '{path}'; exit 1; fi")
 
+with subtest("Check that the key service is started for post-activation keys"):
+    alpha.wait_for_unit("post-activation-key.service")
+
 with subtest("Check that key services respond to key file changes"):
-    alpha.require_unit_state("key-text-key.service", "active")
+    alpha.wait_for_unit("key-text-key.service")
 
     alpha.succeed("rm /run/keys/key-text")
-    alpha.wait_until_succeeds("systemctl --no-pager show key-text-key.service | grep ActiveState=inactive", timeout=10)
+    alpha.require_unit_state("key-text-key.service", "activating")
 
     alpha.succeed("touch /run/keys/key-text")
     alpha.wait_for_unit("key-text-key.service")


### PR DESCRIPTION
Resurrecting #116.  It looks, from testing, the systemd path units aren't actually reliable for triggering when files are created.  So they'll work fine if you use them on keys that are configured to a `destDir` such that the keys exist on boot, but they won't work consistently if you boot and then use `colmena upload-keys`.

This PR replaces the systemd path based implementation with the proven-reliable implementation from nixops.  I literally copy-pasted the unit configuration over from [here](https://github.com/NixOS/nixops/blob/master/nix/keys.nix#L235-L261).

I've confirmed on my own configs that this fixes all the problems I was having with the reliability of the key services.  However, I haven't yet put together a minimal repro.  I could work on doing that if you felt it was necessary @zhaofengli , but it will kind of be a pain and I am super confident in this change now so I'd prefer not to :).