### PR TITLE
Remove usage of impure variable `builtins.currentSystem` in eval.nix when using flakes

### DIFF
--- a/src/nix/hive/eval.nix
+++ b/src/nix/hive/eval.nix
@@ -77,7 +77,7 @@ let
         outputs = { nixpkgs, ... }: {
           colmena = {
             ${configName} = import nixpkgs {
-              system = "${currentSystem}";
+              system = "x86_64-linux"; # Set your desired system here
               overlays = [];
             };
           };


### PR DESCRIPTION
In the warning for flakes which are using an uninitialized nixpkgs the builtin variable `currentSystem` is accessed, which is impure and leads to an error. This PR replaces the variable with a static hint.