### PR TITLE
fix: 1000 nixpkgs; compat with numtide/nixpkgs-unfree

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -18,10 +18,7 @@
     colmenaOptions = import ./src/nix/hive/options.nix;
     colmenaModules = import ./src/nix/hive/modules.nix;
   in flake-utils.lib.eachSystem supportedSystems (system: let
-    pkgs = import nixpkgs {
-      inherit system;
-      overlays = [];
-    };
+    pkgs = nixpkgs.legacyPackages.${system};
   in rec {
     # We still maintain the expression in a Nixpkgs-acceptable form
     defaultPackage = self.packages.${system}.colmena;


### PR DESCRIPTION
Without this, users are greeted with https://github.com/numtide/nixpkgs-unfree/blob/main/default.nix

When they use `nixpkgs-unfree` like this: https://gitlab.com/dar/home-nix/-/blob/main/flake.nix#L9-10

(and align colmena's `nixpkgs` version like this: https://gitlab.com/dar/home-nix/-/blob/main/flake.nix#L25-28)