### PR TITLE
fix: allow nodeSpecialArgs to override name and nodes

### DIFF
--- a/src/nix/hive/eval.nix
+++ b/src/nix/hive/eval.nix
@@ -151,10 +151,10 @@ let
       colmenaOptions.deploymentOptions
       hive.defaults
     ] ++ configs;
-    specialArgs = hive.meta.specialArgs // (hive.meta.nodeSpecialArgs.${name} or {}) // {
+    specialArgs = {
       inherit name;
       nodes = uncheckedNodes;
-    };
+    } // hive.meta.specialArgs // (hive.meta.nodeSpecialArgs.${name} or {});
   };
 
   nodeNames = filter (name: ! elem name reservedNames) (attrNames hive);


### PR DESCRIPTION
This patch allows nodes to override `nodes` and `name` in their `specialArgs`, which is very useful to allow accessing more systems in case the flake defines other systems additional to colmena nodes.