### PR TITLE
ssh: fix substitution when using experimental `nix copy`

### DIFF
--- a/src/nix/host/ssh.rs
+++ b/src/nix/host/ssh.rs
@@ -273,7 +273,11 @@ impl Ssh {
             ]);
 
             if options.use_substitutes {
-                command.arg("--substitute-on-destination");
+                command.args(&[
+                    "--substitute-on-destination",
+                    // needed due to UX bug in ssh-ng://
+                    "--builders-use-substitutes",
+                ]);
             }
 
             if let Some("drv") = path.extension().and_then(OsStr::to_str) {


### PR DESCRIPTION
This patch fixes the substitution (e.g. `cache.nixos.org`) on remotes when deploying a flake-based `colmena` hive, which implies the use of the experimental `nix3 copy` (since 7fac0278e196ff52cfa2622f62cbbca462db12d5).

I consider this a UX bug in `nix` and its `ssh-ng://` itself.
I _think_ this is because `ssh-ng://` simply hasn't implemented `--substitute-on-builders` yet.
`--builders-use-substitutes` works, however (https://github.com/NixOS/nix/pull/4180).

The old/legacy `ssh://` does not have this issue with `nix3 copy`.

I'll try to look a bit more into this in the future and will consider submitting a patch in upstream.
But for now, this patch should suffice.

Especially considering it will take quite some time until that patch is available in a new `nix` release and installed on everyone's hosts :^)