### PR TITLE
Prevent usage of SSH persistent connections

### DIFF
--- a/src/nix/host/ssh.rs
+++ b/src/nix/host/ssh.rs
@@ -345,6 +345,8 @@ impl Ssh {
             "-o",
             "BatchMode=yes",
             "-T",
+            "-o", "ControlMaster=no",
+            "-o", "ControlPath=/dev/null",
         ]
         .iter()
         .map(|s| s.to_string())

--- a/src/nix/host/ssh.rs
+++ b/src/nix/host/ssh.rs
@@ -346,7 +346,7 @@ impl Ssh {
             "BatchMode=yes",
             "-T",
             "-o", "ControlMaster=no",
-            "-o", "ControlPath=/dev/null",
+            "-o", "ControlPath=/var/empty/non-existant",
         ]
         .iter()
         .map(|s| s.to_string())


### PR DESCRIPTION
Deployment sometimes get stuck on "Pushed system closure" if SSH control master already exists for the connection to make.

This is more like a bug in the nix SSH implementation which is usually mitigated by setting these options in `NIX_SSHOPTS`.