### PR TITLE
Add a lib function to extract nixosConfigurations from raw flake

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -104,6 +104,11 @@
       inherit rawHive colmenaOptions colmenaModules;
       hermetic = true;
     };
+
+    lib.fromRawFlake = rawFlake: import ./src/nix/hive/eval.nix {
+      inherit rawFlake colmenaOptions colmenaModules;
+      hermetic = true;
+    };
   };
 
   nixConfig = {


### PR DESCRIPTION
This PR adds a function to load colmena hive from the flake.

Use case:
If I have a flake output like this:
```
  outputs = {}: {
    colmena = {
      systemA = {...};
      systemB = {...};
    };
  }
```
Currently I have no way to obtain the nixosConfiguration associated to systemA and systemB. With this new function, I can now do for instance
```
  inputs.colmena = "github:zhaofengli/colmena";
  outputs = { colmena }: {
    nixosConfiguration = (colmena.fromRawFlake self).nodes;
    colmena = {
      systemA = {...};
      systemB = {...};
    };
  }
```

And this nixosConfiguration will contain the same system as the one that would be built by colmena. This is incomplete (keys are not uploaded), but it is still useful in (at least) two situations:
- If I want to test the configuration in a VM (or anywhere)
- If I want to bootstrap the machine with for instance https://github.com/numtide/nixos-anywhere

This function roughly adds the same content as what "colmena repl" gives access to, but in a nix evaluation context.