### PR TITLE
Set exit code > 0 when colmena exec fails

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -75,6 +75,9 @@ pub enum ColmenaError {
 
     #[snafu(display("Unknown error: {}", message))]
     Unknown { message: String },
+
+    #[snafu(display("Exec failed on {} hosts", n_hosts))]
+    ExecError { n_hosts: usize },
 }
 
 impl From<std::io::Error> for ColmenaError {


### PR DESCRIPTION
Hello and thanks for your great software.

I'm interested in using `colmena exec <command>` from other scripts. It would be helpful if colmena returned a non-zero exit code if `<command>` fails on some hosts. In the current version from `nixos-23.11`, the exit code is always 0.

The proposed change achieves this. I'm neither proficient with rust nor have I spent much time reading the code. Feel free to rewrite if you see a more appropriate solution. Also looking forward to your comments.