### PR TITLE
make eval.nix more convnient to use for non-flake user

### DIFF
--- a/src/nix/hive/eval.nix
+++ b/src/nix/hive/eval.nix
@@ -1,8 +1,8 @@
 { rawHive ? null               # Colmena Hive attrset
 , rawFlake ? null              # Nix Flake attrset with `outputs.colmena`
 , hermetic ? rawFlake != null  # Whether we are allowed to use <nixpkgs>
-, colmenaOptions
-, colmenaModules
+, colmenaOptions ? import ./options.nix
+, colmenaModules ? import ./modules.nix
 }:
 with builtins;
 let


### PR DESCRIPTION
Currently the flake.nix already sets both of these options for lib.makeHive, but this makes it more convenient for non-flake users to also just directly use the eval.nix 