### PR TITLE
lib.mdDoc has been deprecated since 24.05

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -33,11 +33,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1696019113,
-        "narHash": "sha256-X3+DKYWJm93DRSdC5M6K5hLqzSya9BjibtBsuARoPco=",
+        "lastModified": 1725103162,
+        "narHash": "sha256-Ym04C5+qovuQDYL/rKWSR+WESseQBbNAe5DsXNx5trY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f5892ddac112a1e9b3612c39af1b72987ee5783a",
+        "rev": "12228ff1752d7b7624a54e9c1af4b222b3c1073b",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -57,16 +57,16 @@
     },
     "stable": {
       "locked": {
-        "lastModified": 1696039360,
-        "narHash": "sha256-g7nIUV4uq1TOVeVIDEZLb005suTWCUjSY0zYOlSBsyE=",
+        "lastModified": 1724316499,
+        "narHash": "sha256-Qb9MhKBUTCfWg/wqqaxt89Xfi6qTD3XpTzQ9eXi3JmE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "32dcb45f66c0487e92db8303a798ebc548cadedc",
+        "rev": "797f7dc49e0bc7fab4b57c021cdf68f595e47841",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-23.05",
+        "ref": "nixos-24.05",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -3,7 +3,7 @@
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
-    stable.url = "github:NixOS/nixpkgs/nixos-23.05";
+    stable.url = "github:NixOS/nixpkgs/nixos-24.05";
 
     flake-utils.url = "github:numtide/flake-utils";
 

--- a/flake.nix
+++ b/flake.nix
@@ -83,11 +83,21 @@
     in if pkgs.stdenv.isLinux then import ./integration-tests {
       pkgs = import nixpkgs {
         inherit system;
-        overlays = [ self.overlays.default inputsOverlay ];
+        overlays = [
+          self.overlays.default
+          inputsOverlay
+
+          self._evalJobsOverlay
+        ];
       };
       pkgsStable = import stable {
         inherit system;
-        overlays = [ self.overlays.default inputsOverlay ];
+        overlays = [
+          self.overlays.default
+          inputsOverlay
+
+          self._evalJobsOverlay
+        ];
       };
     } else {};
   }) // {
@@ -103,6 +113,23 @@
     lib.makeHive = rawHive: import ./src/nix/hive/eval.nix {
       inherit rawHive colmenaOptions colmenaModules;
       hermetic = true;
+    };
+
+    # Temporary fork of nix-eval-jobs with changes to be upstreamed
+    # Mostly for the integration test setup and not needed in most use cases
+    _evalJobsOverlay = final: prev: let
+      patched = prev.nix-eval-jobs.overrideAttrs (old: {
+        version = old.version + "-colmena";
+        patches = (old.patches or []) ++ [
+          # Allows NIX_PATH to be honored
+          (final.fetchpatch {
+            url = "https://github.com/zhaofengli/nix-eval-jobs/commit/6ff5972724230ac2b96eb1ec355cd25ca512ef57.patch";
+            hash = "sha256-2NiMYpw27N+X7Ixh2HkP3fcWvopDJWQDVjgRdhOL2QQ";
+          })
+        ];
+      });
+    in {
+      nix-eval-jobs = patched;
     };
   };
 

--- a/integration-tests/tools.nix
+++ b/integration-tests/tools.nix
@@ -129,6 +129,9 @@ let
       extraDeployerConfig
     ];
 
+    # FIXME: Colmena flake support is broken with Nix 2.24
+    nix.package = pkgs.nixVersions.nix_2_18;
+
     nix.registry = lib.mkIf (pkgs ? _inputs) {
       nixpkgs.flake = pkgs._inputs.nixpkgs;
     };

--- a/integration-tests/tools.nix
+++ b/integration-tests/tools.nix
@@ -140,7 +140,7 @@ let
     nix.settings.substituters = lib.mkForce [];
 
     virtualisation = {
-      memorySize = 4096;
+      memorySize = 6144;
       writableStore = true;
       additionalPaths = [
         "${pkgs.path}"

--- a/src/nix/hive/options.nix
+++ b/src/nix/hive/options.nix
@@ -1,18 +1,17 @@
 with builtins; rec {
   keyType = { lib, name, config, ... }: let
     inherit (lib) types;
-    mdDoc = lib.mdDoc or (md: md);
   in {
     options = {
       name = lib.mkOption {
-        description = mdDoc ''
+        description = ''
           File name of the key.
         '';
         default = name;
         type = types.str;
       };
       text = lib.mkOption {
-        description = mdDoc ''
+        description = ''
           Content of the key.
           One of `text`, `keyCommand` and `keyFile` must be set.
         '';
@@ -20,7 +19,7 @@ with builtins; rec {
         type = types.nullOr types.str;
       };
       keyFile = lib.mkOption {
-        description = mdDoc ''
+        description = ''
           Path of the local file to read the key from.
           One of `text`, `keyCommand` and `keyFile` must be set.
         '';
@@ -29,7 +28,7 @@ with builtins; rec {
         type = types.nullOr types.path;
       };
       keyCommand = lib.mkOption {
-        description = mdDoc ''
+        description = ''
           Command to run to generate the key.
           One of `text`, `keyCommand` and `keyFile` must be set.
         '';
@@ -39,14 +38,14 @@ with builtins; rec {
         in types.nullOr nonEmptyList;
       };
       destDir = lib.mkOption {
-        description = mdDoc ''
+        description = ''
           Destination directory on the host.
         '';
         default = "/run/keys";
         type = types.path;
       };
       path = lib.mkOption {
-        description = mdDoc ''
+        description = ''
           Full path to the destination.
         '';
         default = "${config.destDir}/${config.name}";
@@ -54,28 +53,28 @@ with builtins; rec {
         internal = true;
       };
       user = lib.mkOption {
-        description = mdDoc ''
+        description = ''
           The group that will own the file.
         '';
         default = "root";
         type = types.str;
       };
       group = lib.mkOption {
-        description = mdDoc ''
+        description = ''
           The group that will own the file.
         '';
         default = "root";
         type = types.str;
       };
       permissions = lib.mkOption {
-        description = mdDoc ''
+        description = ''
           Permissions to set for the file.
         '';
         default = "0600";
         type = types.str;
       };
       uploadAt = lib.mkOption {
-        description = mdDoc ''
+        description = ''
           When to upload the keys.
 
           - pre-activation (default): Upload the keys before activating the new system profile.
@@ -94,12 +93,11 @@ with builtins; rec {
   # Largely compatible with NixOps/Morph.
   deploymentOptions = { name, lib, ... }: let
     inherit (lib) types;
-    mdDoc = lib.mdDoc or (md: md);
   in {
     options = {
       deployment = {
         targetHost = lib.mkOption {
-          description = mdDoc ''
+          description = ''
             The target SSH node for deployment.
 
             By default, the node's attribute name will be used.
@@ -109,7 +107,7 @@ with builtins; rec {
           default = name;
         };
         targetPort = lib.mkOption {
-          description = mdDoc ''
+          description = ''
             The target SSH port for deployment.
 
             By default, the port is the standard port (22) or taken
@@ -119,7 +117,7 @@ with builtins; rec {
           default = null;
         };
         targetUser = lib.mkOption {
-          description = mdDoc ''
+          description = ''
             The user to use to log into the remote node. If set to null, the
             target user will not be specified in SSH invocations.
           '';
@@ -127,7 +125,7 @@ with builtins; rec {
           default = "root";
         };
         allowLocalDeployment = lib.mkOption {
-          description = mdDoc ''
+          description = ''
             Allow the configuration to be applied locally on the host running
             Colmena.
 
@@ -144,7 +142,7 @@ with builtins; rec {
           default = false;
         };
         buildOnTarget = lib.mkOption {
-          description = mdDoc ''
+          description = ''
             Whether to build the system profiles on the target node itself.
 
             When enabled, Colmena will copy the derivation to the target
@@ -164,7 +162,7 @@ with builtins; rec {
           default = false;
         };
         tags = lib.mkOption {
-          description = mdDoc ''
+          description = ''
             A list of tags for the node.
 
             Can be used to select a group of nodes for deployment.
@@ -173,7 +171,7 @@ with builtins; rec {
           default = [];
         };
         keys = lib.mkOption {
-          description = mdDoc ''
+          description = ''
             A set of secrets to be deployed to the node.
 
             Secrets are transferred to the node out-of-band and
@@ -183,7 +181,7 @@ with builtins; rec {
           default = {};
         };
         replaceUnknownProfiles = lib.mkOption {
-          description = mdDoc ''
+          description = ''
             Allow a configuration to be applied to a host running a profile we
             have no knowledge of. By setting this option to false, you reduce
             the likelyhood of rolling back changes made via another Colmena user.
@@ -199,7 +197,7 @@ with builtins; rec {
           default = true;
         };
         privilegeEscalationCommand = lib.mkOption {
-          description = mdDoc ''
+          description = ''
             Command to use to elevate privileges when activating the new profiles on SSH hosts.
 
             This is used on SSH hosts when `deployment.targetUser` is not `root`.
@@ -209,7 +207,7 @@ with builtins; rec {
           default = [ "sudo" "-H" "--" ];
         };
         sshOptions = lib.mkOption {
-          description = mdDoc ''
+          description = ''
             Extra SSH options to pass to the SSH command.
           '';
           type = types.listOf types.str;
@@ -221,29 +219,28 @@ with builtins; rec {
   # Hive-wide options
   metaOptions = { lib, ... }: let
     inherit (lib) types;
-    mdDoc = lib.mdDoc or (md: md);
   in {
     options = {
       name = lib.mkOption {
-        description = mdDoc ''
+        description = ''
           The name of the configuration.
         '';
         type = types.str;
         default = "hive";
       };
       description = lib.mkOption {
-        description = mdDoc ''
+        description = ''
           A short description for the configuration.
         '';
         type = types.str;
         default = "A Colmena Hive";
       };
       nixpkgs = lib.mkOption {
-        description = mdDoc ''
+        description = ''
           The pinned Nixpkgs package set. Accepts one of the following:
 
           - A path to a Nixpkgs checkout
-          - The Nixpkgs lambda (e.g., import \<nixpkgs\>)
+          - The Nixpkgs lambda (e.g., import <nixpkgs>)
           - An initialized Nixpkgs attribute set
 
           This option must be specified when using Flakes.
@@ -252,21 +249,21 @@ with builtins; rec {
         default = null;
       };
       nodeNixpkgs = lib.mkOption {
-        description = mdDoc ''
+        description = ''
           Node-specific Nixpkgs pins.
         '';
         type = types.attrsOf types.unspecified;
         default = {};
       };
       nodeSpecialArgs = lib.mkOption {
-        description = mdDoc ''
+        description = ''
           Node-specific special args.
         '';
         type = types.attrsOf types.unspecified;
         default = {};
       };
       machinesFile = lib.mkOption {
-        description = mdDoc ''
+        description = ''
           Use the machines listed in this file when building this hive configuration.
 
           If your Colmena host has nix configured to allow for remote builds
@@ -290,7 +287,7 @@ with builtins; rec {
         type = types.nullOr types.path;
       };
       specialArgs = lib.mkOption {
-        description = mdDoc ''
+        description = ''
           A set of special arguments to be passed to NixOS modules.
 
           This will be merged into the `specialArgs` used to evaluate
@@ -300,7 +297,7 @@ with builtins; rec {
         type = types.attrsOf types.unspecified;
       };
       allowApplyAll = lib.mkOption {
-        description = mdDoc ''
+        description = ''
           Whether to allow deployments without a node filter set.
 
           If set to false, a node filter must be specified with `--on` when


### PR DESCRIPTION
`lib.mdDoc` emits this trace when called since 24.05:

```quote
trace: warning: lib.mdDoc will be removed from nixpkgs in 24.11. Option descriptions are now in Markdown by default; you can remove any remaining uses of lib.mdDoc.
```

Given that this was introduced with 22.11 and made obsolete in 24.05 with all prior versions being EoL at this point it should be safe to revert that change. In any case the only result will be that anything ≥22.11 and <24.05 will be rendered without markup which I guess isn't the best, but given those are EoL systems it's not the worst.

Either way it gets rid of a *lot* of noise for 24.05 users in the trace, and for 24.11 and up it will remove dead code.

This reverts commit 7602e548a78932bd28a7e2f621b3d62b4124e993.