### PR TITLE
resolve TempDir paths before passing them to the flake bin

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,6 @@
 name: Build
 on:
+  pull_request:
   push:
 jobs:
   build:

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -1,6 +1,7 @@
 name: Linters
 
 on:
+  pull_request:
   push:
 jobs:
   linters:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,5 +1,6 @@
 name: Tests
 on:
+  pull_request:
   push:
 jobs:
   tests:

--- a/src/nix/hive/assets.rs
+++ b/src/nix/hive/assets.rs
@@ -51,7 +51,10 @@ impl Assets {
             // We explicitly specify `path:` instead of letting Nix resolve
             // automatically, which would involve checking parent directories
             // for a git repository.
-            let uri = format!("path:{}", temp_dir.path().to_str().unwrap());
+            let uri = format!(
+                "path:{}",
+                temp_dir.path().canonicalize().unwrap().to_str().unwrap()
+            );
             let _ = lock_flake_quiet(&uri).await;
             let assets_flake = Flake::from_uri(uri).await?;
             assets_flake_uri = Some(assets_flake.locked_uri().to_owned());


### PR DESCRIPTION
On macOS `/tmp` is a symlink to `/private/tmp`.
TempDir creates a dir and returns the path as `/tmp/...`. nix is unhappy with symlink dirs when calling `nix flake metadata --json path:...`

```
error (ignored): error: end of string reached
error:
       … while fetching the input 'path:/tmp/colmena-assets-XHHAXJ'

       error: path '/tmp' is a symlink
thread 'main' panicked at src/cli.rs:286:38:
Failed to get flake or hive: ChildFailure { exit_code: 1, backtrace:    0: backtrace::capture::Backtrace::new
   1: colmena::nix::flake::FlakeMetadata::resolve::{{closure}}
   2: colmena::nix::flake::Flake::from_uri::{{closure}}
   3: colmena::cli::run::{{closure}}
   4: tokio::runtime::park::CachedParkThread::block_on
   5: colmena::main
   6: std::sys_common::backtrace::__rust_begin_short_backtrace
   7: std::rt::lang_start::{{closure}}
   8: std::panicking::try
   9: std::rt::lang_start_internal
  10: _main
 }
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```



To fix this we canonicalize the path first, resolving any symlinks on the way.