### PR TITLE
flake: fix patch for nix-eval-jobs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -53,11 +53,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1730785428,
-        "narHash": "sha256-Zwl8YgTVJTEum+L+0zVAWvXAGbWAuXHax3KzuejaDyo=",
+        "lastModified": 1734119587,
+        "narHash": "sha256-AKU6qqskl0yf2+JdRdD0cfxX4b9x3KKV5RqA6wijmPM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "4aa36568d413aca0ea84a1684d2d46f55dbabad7",
+        "rev": "3566ab7246670a43abd2ffa913cc62dad9cdf7d5",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -36,11 +36,11 @@
       patched = prev.nix-eval-jobs.overrideAttrs (old: {
         version = old.version + "-colmena";
         patches = (old.patches or []) ++ [
-          # Allows NIX_PATH to be honored
-          (final.fetchpatch {
-            url = "https://github.com/zhaofengli/nix-eval-jobs/commit/6ff5972724230ac2b96eb1ec355cd25ca512ef57.patch";
-            hash = "sha256-2NiMYpw27N+X7Ixh2HkP3fcWvopDJWQDVjgRdhOL2QQ";
-          })
+          (if builtins.compareVersions old.version "2.25.0" >= 0 then
+            ./nix-eval-jobs-unstable.patch
+          else
+            ./nix-eval-jobs-stable.patch
+          )
         ];
       });
     in {

--- a/integration-tests/tools.nix
+++ b/integration-tests/tools.nix
@@ -29,7 +29,7 @@ let
   nixosLib = import (pkgs.path + "/nixos/lib") { };
 
   inputClosureOf = pkg: pkgs.runCommand "full-closure" {
-    refs = pkgs.writeReferencesToFile pkg.drvPath;
+    refs = pkgs.writeClosure [ pkg.drvPath ];
   } ''
     touch $out
 

--- a/nix-eval-jobs-stable.patch
+++ b/nix-eval-jobs-stable.patch
@@ -1,0 +1,25 @@
+From 6ff5972724230ac2b96eb1ec355cd25ca512ef57 Mon Sep 17 00:00:00 2001
+From: Zhaofeng Li <hello@zhaofeng.li>
+Date: Sat, 5 Oct 2024 17:59:04 -0600
+Subject: [PATCH] Allow NIX_PATH environment variable
+
+---
+ src/nix-eval-jobs.cc | 5 -----
+ 1 file changed, 5 deletions(-)
+
+diff --git a/src/nix-eval-jobs.cc b/src/nix-eval-jobs.cc
+index de7a2bcf..30de4c53 100644
+--- a/src/nix-eval-jobs.cc
++++ b/src/nix-eval-jobs.cc
+@@ -342,11 +342,6 @@ void collector(Sync<State> &state_, std::condition_variable &wakeup) {
+ }
+ 
+ int main(int argc, char **argv) {
+-
+-    /* Prevent undeclared dependencies in the evaluation via
+-       $NIX_PATH. */
+-    unsetenv("NIX_PATH");
+-
+     /* We are doing the garbage collection by killing forks */
+     setenv("GC_DONT_GC", "1", 1);
+ 

--- a/nix-eval-jobs-unstable.patch
+++ b/nix-eval-jobs-unstable.patch
@@ -1,0 +1,16 @@
+diff --git a/src/nix-eval-jobs.cc b/src/nix-eval-jobs.cc
+index 13d610c..e5e6a0f 100644
+--- a/src/nix-eval-jobs.cc
++++ b/src/nix-eval-jobs.cc
+@@ -376,11 +376,6 @@ void collector(nix::Sync<State> &state_, std::condition_variable &wakeup) {
+ } // namespace
+ 
+ auto main(int argc, char **argv) -> int {
+-
+-    /* Prevent undeclared dependencies in the evaluation via
+-       $NIX_PATH. */
+-    unsetenv("NIX_PATH"); // NOLINT(concurrency-mt-unsafe)
+-
+     /* We are doing the garbage collection by killing forks */
+     setenv("GC_DONT_GC", "1", 1); // NOLINT(concurrency-mt-unsafe)
+ 


### PR DESCRIPTION
We carry a custom patch for nix-eval-jobs that causes the tool to not unset the `NIX_PATH` environment variable anymore. The patch does not apply anymore starting with d0bcdae (clang-tidy: use trailing return type, 2024-11-10) because surrounding code has changed. Other than that the patch still applies.

The mentioned commit was released with nix-eval-jobs v2.25.0, which nixos-unstable has recently upgraded to. Adapt the patch to unbreak the build.

Fixes #255.