### PR TITLE
Make nix_flags_with_builders call nix_flags

### DIFF
--- a/src/nix/hive/mod.rs
+++ b/src/nix/hive/mod.rs
@@ -237,8 +237,7 @@ impl Hive {
 
     /// Returns Nix flags to set for this Hive, with configured remote builders.
     pub async fn nix_flags_with_builders(&self) -> ColmenaResult<NixFlags> {
-        let mut flags = NixFlags::default();
-        flags.set_show_trace(self.show_trace);
+        let mut flags = self.nix_flags();
 
         if let Some(machines_file) = &self.get_meta_config().await?.machines_file {
             flags.set_builders(Some(format!("@{}", machines_file)));

--- a/src/nix/host/local.rs
+++ b/src/nix/host/local.rs
@@ -46,7 +46,7 @@ impl Host for Local {
     async fn realize_remote(&mut self, derivation: &StorePath) -> ColmenaResult<Vec<StorePath>> {
         let mut command = Command::new("nix-store");
 
-        command.args(self.nix_options.to_args());
+        command.args(self.nix_options.to_nix_store_args());
         command
             .arg("--no-gc-warning")
             .arg("--realise")

--- a/src/nix/mod.rs
+++ b/src/nix/mod.rs
@@ -217,6 +217,15 @@ impl NixFlags {
     }
 
     pub fn to_args(&self) -> Vec<String> {
+        self.to_args_inner(false)
+    }
+
+    /// Returns arguments for `nix-store`.
+    pub fn to_nix_store_args(&self) -> Vec<String> {
+        self.to_args_inner(true)
+    }
+
+    fn to_args_inner(&self, nix_store: bool) -> Vec<String> {
         let mut args = Vec::new();
 
         if let Some(builders) = &self.builders {
@@ -235,7 +244,10 @@ impl NixFlags {
             args.push("--pure-eval".to_string());
         }
 
-        if self.impure {
+        // The `nix-store` command does not accept `--impure`
+        // TODO: Not happy about this solution - Have a better Nix abstraction that hides
+        // CLI details (e.g., nix3 CLI differences)
+        if self.impure && !nix_store {
             args.push("--impure".to_string());
         }
 


### PR DESCRIPTION
I noticed that setting `--nix-option extra-substituters ... --nix-option extra-trusted-public-keys ...` did not allow colmena to substitute things from an internal cache while building nodes. I eventually traced this to `Hive::nix_flags_with_builders` not including the options in the same way that `Hive::nix_flags` does. I did not immediately see any reason why `nix_flags_with_builders` should ever return fewer flags than `nix_flags`, so I just modified `nix_flags_with_builders` to start by calling `nix_flags`. If there's a reason that I'm not aware of, please let me know what it is, and I'll think about this some more.

There are two failing tests, but they were failing on `main`, too, so I don't think I caused the breakage.

I was able to build our configuration, hitting our internal cache, with this modification.