### PR TITLE
Add meta.mainProgram

### DIFF
--- a/package.nix
+++ b/package.nix
@@ -49,5 +49,6 @@ rustPlatform.buildRustPackage rec {
     license = licenses.mit;
     maintainers = with maintainers; [ zhaofengli ];
     platforms = platforms.linux ++ platforms.darwin;
+    mainProgram = "colmena";
   };
 }


### PR DESCRIPTION
So that we can `nixpkgs.lib.getExe` without worry.