### PR TITLE
feat: add keys systemd serviceName option

### DIFF
--- a/src/nix/hive/modules.nix
+++ b/src/nix/hive/modules.nix
@@ -66,7 +66,7 @@ with builtins; {
     # <https://github.com/systemd/systemd/issues/3642>
     keyServiceModule = { pkgs, lib, config, ... }: {
       systemd.paths = lib.mapAttrs' (name: val: {
-        name = "${name}-key";
+        name = config.serviceName;
         value = {
           wantedBy = [ "paths.target" ];
           pathConfig = {
@@ -76,7 +76,7 @@ with builtins; {
       }) config.deployment.keys;
 
       systemd.services = lib.mapAttrs' (name: val: {
-        name = "${name}-key";
+        name = config.serviceName;
         value = {
           enable = true;
           serviceConfig = {

--- a/src/nix/hive/options.nix
+++ b/src/nix/hive/options.nix
@@ -10,6 +10,13 @@ with builtins; rec {
         default = name;
         type = types.str;
       };
+      serviceName = lib.mkOption {
+        description = ''
+          Name of the systemd services.
+        '';
+        default = "${config.name}-key";
+        type = types.str;
+      };
       text = lib.mkOption {
         description = ''
           Content of the key.


### PR DESCRIPTION
Adds a new option in the keys attribute set to override the key service name. The default service name remains the name of the key suffixed with "-key" BUT the semantics changes a bit.

With this key declaration:

```nix
{
  keys.my-secret {
    name = "my-pretty-secret";
    ....
  } 
}
```

Before the service would have called `my-secret-key` while then it will be called `my-pretty-secret-key`. I think it's better to use the actual value of key `name` instead of the default value for the option key `name`.

This change also allows referring to the service name with the option `config.keys.my-secret.serviceName` in other services.