### PR TITLE
fix(nix-eval-jobs): silence warning when overriding version without src

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -42,6 +42,8 @@
             ./nix-eval-jobs-stable.patch
           )
         ];
+        # To silence the warning, since we intend to change the version without overriding the src.
+        __intentionallyOverridingVersion = true;
       });
     in {
       nix-eval-jobs = patched;


### PR DESCRIPTION
Set `__intentionallyOverridingVersion` = true to explicitly suppress the warning,
as we are intentionally changing the version without changing the src.

https://github.com/NixOS/nixpkgs/blob/bf8cde15eee43c9576ebc8ded247e4783736098f/pkgs/stdenv/generic/make-derivation.nix#L109-L129

```
evaluation warning: nix-eval-jobs-2.29.0 was overridden with `version` but not `src` at /nix/store/3diqksc2c5dl8517mq71pgyabxc250y5-source/flake.nix:37:9.

                    This is most likely not what you want. In order to properly change the version of a package, override
                    both the `version` and `src` attributes:

                    hello.overrideAttrs (oldAttrs: rec {
                      version = "1.0.0";
                      src = pkgs.fetchurl {
                        url = "mirror://gnu/hello/hello-${version}.tar.gz";
                        hash = "...";
                      };
                    })

                    (To silence this warning, set `__intentionallyOverridingVersion = true` in your `overrideAttrs` call.)
```
