### PR TITLE
fix: Chown correct path for pre-activation keys

### DIFF
--- a/src/nix/hive/modules.nix
+++ b/src/nix/hive/modules.nix
@@ -19,7 +19,7 @@ with builtins; {
       scriptDeps = if config.system.activationScripts ? groups then [ "groups" ] else [ "users" ];
 
       commands = lib.mapAttrsToList (name: key: let
-        keyPath = "${key.destDir}/${name}";
+        keyPath = "${key.destDir}/${key.name}";
       in ''
         if [ -f "${keyPath}" ]; then
           if ! chown ${key.user}:${key.group} "${keyPath}"; then


### PR DESCRIPTION
If you change the [name of a pre-activation key](https://colmena.cli.rs/unstable/reference/deployment.html#deploymentkeysnamename), Colmena will chown the wrong key path.