### PR TITLE
Don't use patched version of nix-eval-jobs if version >= 2.30.0

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -64,12 +64,18 @@
     flake-utils.lib.eachSystem supportedSystems (
       system:
       let
-        pkgs = import nixpkgs {
-          inherit system;
-          overlays = [
-            _evalJobsOverlay
-          ];
-        };
+        nix-eval-jobs = nixpkgs.legacyPackages.${system}.nix-eval-jobs;
+
+        pkgs =
+          if builtins.compareVersions nix-eval-jobs.version "2.30.0" >= 0 then
+            nixpkgs.legacyPackages.${system}
+          else
+            import nixpkgs {
+              inherit system;
+              overlays = [
+                _evalJobsOverlay
+              ];
+            };
       in
       rec {
         # We still maintain the expression in a Nixpkgs-acceptable form


### PR DESCRIPTION
I disabled the overlay with the patched nix-eval-jobs when it's version < 2.30.0.

Fixes #302