### PR TITLE
flake: drop patches for nix-eval-jobs v2.30 and newer

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -45,14 +45,14 @@
         let
           patched = prev.nix-eval-jobs.overrideAttrs (old: {
             version = old.version + "-colmena";
-            patches = (old.patches or [ ]) ++ [
-              (
-                if builtins.compareVersions old.version "2.25.0" >= 0 then
-                  ./nix-eval-jobs-unstable.patch
-                else
-                  ./nix-eval-jobs-stable.patch
-              )
-            ];
+            patches = (old.patches or [ ]) ++ (
+              if builtins.compareVersions old.version "2.30.0" >= 0 then
+                [ ]
+              else if builtins.compareVersions old.version "2.25.0" >= 0 then
+                [ ./nix-eval-jobs-unstable.patch ]
+              else
+                [ ./nix-eval-jobs-stable.patch ]
+            );
             # To silence the warning, since we intend to change the version without overriding the src.
             __intentionallyOverridingVersion = true;
           });


### PR DESCRIPTION
In f584ae8 (no longer unset NIX_PATH, 2025-05-31), nix-eval-jobs has dropped code that unsets the NIX_PATH environment variable. This part is something we have been patching out since quite a while. Consequently, the patch is now not necessary anymore starting with the 2.30.0 release.

Drop the patch starting with that version.