### PR TITLE
deployment: Fix typo that broke --eval-node-limit=0

### DIFF
--- a/src/nix/deployment/mod.rs
+++ b/src/nix/deployment/mod.rs
@@ -203,7 +203,7 @@ impl Deployment {
         let eval_limit = self
             .evaluation_node_limit
             .get_limit()
-            .unwrap_or(self.targets.len());
+            .unwrap_or(targets.len());
 
         let mut futures = Vec::new();
 


### PR DESCRIPTION
`self.targets` is always empty at this stage.

The code is a bit smelly with both `self.targets` and `targets` there. Let's fix the problem and refactor later.

Fixes #310.