### PR TITLE
Forward lib from nodeNixpkgs to evalConfig

### DIFF
--- a/src/nix/hive/eval.nix
+++ b/src/nix/hive/eval.nix
@@ -142,6 +142,7 @@ let
     };
   in evalConfig {
     inherit (npkgs.stdenv.hostPlatform) system;
+    inherit (npkgs) lib;
 
     modules = [
       nixpkgsModule


### PR DESCRIPTION
This defaults to `import "${npkgs}/lib"`, which if `npkgs` comes from a flake has a fallback `lib.trivial.version` like `25.11pre-git` instead of the correct `25.11.20250828.dfb2f12`.