### PR TITLE
fix: replace deprecated pkgs.system with pkgs.stdenv.hostPlatform.system

### DIFF
--- a/src/nix/hive/eval.nix
+++ b/src/nix/hive/eval.nix
@@ -141,7 +141,7 @@ let
         "The following Nixpkgs configuration keys set in meta.nixpkgs will be ignored: ${toString remainingKeys}";
     };
   in evalConfig {
-    inherit (npkgs) system;
+    inherit (npkgs.stdenv.hostPlatform) system;
 
     modules = [
       nixpkgsModule


### PR DESCRIPTION
Change the system value source to avoid using deprecated name; see https://github.com/NixOS/nixpkgs/commit/90cb7876446bf1684ffe40ab7832de0ec1b92991