### PR TITLE
feat: Add nix-darwin (macOS) deployment support

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -177,7 +177,6 @@ struct Opts {
 enum Command {
     Apply(command::apply::Opts),
 
-    #[cfg(target_os = "linux")]
     ApplyLocal(command::apply_local::Opts),
 
     /// Build configurations but not push to remote machines
@@ -330,7 +329,6 @@ pub async fn run() {
 
     match opts.command {
         Command::Apply(args) => r(command::apply::run(hive, args), opts.config).await,
-        #[cfg(target_os = "linux")]
         Command::ApplyLocal(args) => r(command::apply_local::run(hive, args), opts.config).await,
         Command::Eval(args) => r(command::eval::run(hive, args), opts.config).await,
         Command::Exec(args) => r(command::exec::run(hive, args), opts.config).await,

--- a/src/command/apply_local.rs
+++ b/src/command/apply_local.rs
@@ -66,16 +66,21 @@ pub async fn run(
         quit::with_code(1);
     }
 
-    // Sanity check: Are we running NixOS?
-    if let Ok(os_release) = fs::read_to_string("/etc/os-release").await {
-        let re = Regex::new(r#"ID="?nixos"?"#).unwrap();
-        if !re.is_match(&os_release) {
-            tracing::error!("\"apply-local\" only works on NixOS machines.");
+    // Sanity check: Are we running NixOS or macOS (nix-darwin)?
+    let is_darwin = cfg!(target_os = "macos");
+    if !is_darwin {
+        if let Ok(os_release) = fs::read_to_string("/etc/os-release").await {
+            let re = Regex::new(r#"ID="?nixos"?"#).unwrap();
+            if !re.is_match(&os_release) {
+                tracing::error!(
+                    "\"apply-local\" only works on NixOS or macOS (nix-darwin) machines."
+                );
+                quit::with_code(5);
+            }
+        } else {
+            tracing::error!("Could not detect the OS version from /etc/os-release.");
             quit::with_code(5);
         }
-    } else {
-        tracing::error!("Could not detect the OS version from /etc/os-release.");
-        quit::with_code(5);
     }
 
     let verbose = verbose || sudo; // cannot use spinners with interactive sudo

--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -4,7 +4,6 @@ pub mod exec;
 pub mod nix_info;
 pub mod repl;
 
-#[cfg(target_os = "linux")]
 pub mod apply_local;
 
 #[cfg(debug_assertions)]

--- a/src/error.rs
+++ b/src/error.rs
@@ -46,9 +46,6 @@ pub enum ColmenaError {
     #[snafu(display("Store path {:?} is not a derivation", store_path))]
     NotADerivation { store_path: StorePath },
 
-    #[snafu(display("Invalid NixOS system profile"))]
-    InvalidProfile,
-
     #[snafu(display("Unknown active profile: {:?}", profile))]
     ActiveProfileUnknown { profile: Profile },
 

--- a/src/nix/deployment/goal.rs
+++ b/src/nix/deployment/goal.rs
@@ -104,4 +104,13 @@ impl Goal {
         use Goal::*;
         !matches!(self, Build)
     }
+
+    /// Returns whether this goal is supported for Darwin systems.
+    ///
+    /// Darwin doesn't support the "boot" goal since it doesn't have
+    /// separate boot profiles like NixOS.
+    pub fn supported_on_darwin(&self) -> bool {
+        use Goal::*;
+        !matches!(self, Boot)
+    }
 }

--- a/src/nix/deployment/mod.rs
+++ b/src/nix/deployment/mod.rs
@@ -637,7 +637,8 @@ impl Deployment {
                 }
             }
 
-            host.activate(&profile_r, arc_self.goal).await?;
+            let system_type = target.config.system_type();
+            host.activate(&profile_r, arc_self.goal, system_type).await?;
 
             job.success_with_message(arc_self.goal.success_str().to_string())?;
 
@@ -658,9 +659,11 @@ impl Deployment {
                     None
                 };
 
+                let system_type = target.config.system_type();
                 let options = RebootOptions::default()
                     .wait_for_boot(true)
-                    .new_profile(new_profile);
+                    .new_profile(new_profile)
+                    .system_type(system_type);
 
                 host.reboot(options).await?;
 

--- a/src/nix/hive/eval.nix
+++ b/src/nix/hive/eval.nix
@@ -26,7 +26,6 @@ let
     rawFlake.outputs ? darwinConfigurations &&
     rawFlake.outputs.darwinConfigurations ? ${name};
 
-
   uncheckedHive = let
     flakeToHive = rawFlake:
       if rawFlake.outputs ? colmena then rawFlake.outputs.colmena else throw "Flake must define outputs.colmena.";
@@ -123,25 +122,69 @@ let
   lib = nixpkgs.lib;
   reservedNames = [ "defaults" "darwinDefaults" "network" "meta" ];
 
-  # Determine system type for a node
-  # Priority: 1. Explicit deployment.systemType, 2. Auto-detect from darwinConfigurations
+  # The `specialArgs` passed to every node evaluation.
+  mkSpecialArgs = name: {
+    inherit name;
+    nodes = uncheckedNodes;
+  } // hive.meta.specialArgs // (hive.meta.nodeSpecialArgs.${name} or {});
+
+  # The Nixpkgs to use for a node: its per-node override, else the hive default.
+  npkgsFor = name:
+    if hasAttr name hive.meta.nodeNixpkgs
+    then mkNixpkgs "meta.nodeNixpkgs.${name}" hive.meta.nodeNixpkgs.${name}
+    else nixpkgs;
+
+  # Determine the system type for a node.
+  #
+  # Priority:
+  #   1. An explicit `deployment.systemType` set anywhere in the node's config.
+  #   2. Auto-detection from the flake's `darwinConfigurations`.
+  #   3. Default: "nixos".
+  #
+  # `deployment.systemType` must be read *robustly*: a node config is usually a
+  # module *function* (`{ ... }: { ... }`), whose attributes cannot be observed
+  # by plain attribute introspection. We therefore evaluate only the
+  # platform-independent deployment options through the module system.
+  # `_module.check = false` lets us ignore all the NixOS/darwin options the
+  # config also sets, and lazy evaluation means those unrelated options are
+  # never forced. The probe is wrapped in `tryEval` so a node with unusual
+  # module-argument requirements falls back to attribute introspection rather
+  # than aborting the whole evaluation.
   getNodeSystemType = name: configs: let
-    # Find if any config sets deployment.systemType
-    explicitType = lib.findFirst
+    probe = tryEval (lib.evalModules {
+      modules = [
+        colmenaOptions.deploymentOptions
+        { _module.check = false; _module.args.pkgs = nixpkgs; }
+      ] ++ configs;
+      specialArgs = mkSpecialArgs name;
+    }).config.deployment.systemType;
+
+    # Fallback: attribute introspection, which only sees plain-attrset configs.
+    introspected = lib.findFirst
       (c: c ? deployment && c.deployment ? systemType)
       null
       configs;
+
+    explicitType =
+      if probe.success then probe.value
+      else if introspected != null then introspected.deployment.systemType
+      else "nixos";
   in
-    if explicitType != null then explicitType.deployment.systemType
+    # `probe.value` carries the option default ("nixos") when unset, so we let
+    # flake auto-detection win over a non-explicit "nixos".
+    if explicitType != "nixos" then explicitType
     else if isDarwinFromFlake name then "darwin"
     else "nixos";
 
+  # Memoize per-node system type so the detection probe runs at most once per
+  # node (it is consulted both when evaluating the node and its toplevel).
+  nodeSystemTypes = listToAttrs (map
+    (name: { inherit name; value = getNodeSystemType name (configsFor name); })
+    nodeNames);
+
   # Evaluate a NixOS node
   evalNixOSNode = name: configs: let
-    npkgs =
-      if hasAttr name hive.meta.nodeNixpkgs
-      then mkNixpkgs "meta.nodeNixpkgs.${name}" hive.meta.nodeNixpkgs.${name}
-      else nixpkgs;
+    npkgs = npkgsFor name;
     evalConfig = import (npkgs.path + "/nixos/lib/eval-config.nix");
 
     # Here we need to merge the configurations in meta.nixpkgs
@@ -174,43 +217,34 @@ let
       colmenaOptions.deploymentOptions
       hive.defaults
     ] ++ configs;
-    specialArgs = {
-      inherit name;
-      nodes = uncheckedNodes;
-    } // hive.meta.specialArgs // (hive.meta.nodeSpecialArgs.${name} or {});
+    specialArgs = mkSpecialArgs name;
   };
 
   # Evaluate a darwin node
   evalDarwinNode = name: configs: let
-    npkgs =
-      if hasAttr name hive.meta.nodeNixpkgs
-      then mkNixpkgs "meta.nodeNixpkgs.${name}" hive.meta.nodeNixpkgs.${name}
-      else nixpkgs;
+    npkgs = npkgsFor name;
 
-    # Get the nix-darwin input from meta
+    # Get the nix-darwin input from meta. It must be provided for darwin nodes.
     darwinInput = hive.meta.nix-darwin or null;
-    # Assert that nix-darwin is provided (assigns true to _ if assertion passes)
-    _ = assert lib.assertMsg (darwinInput != null)
-      "meta.nix-darwin must be set when deploying darwin nodes. Add your nix-darwin flake input to meta.nix-darwin.";
-      true;
 
-    # Use darwin's eval-config
-    # nix-darwin provides darwinSystem in lib or as a flake output
+    # Use darwin's eval-config. nix-darwin exposes `darwinSystem` under `lib` or
+    # as a top-level flake output. The null check must live here (not in a
+    # separate `let` binding) so it is actually forced when the node is
+    # evaluated — an unreferenced `assert` binding would never run.
     evalConfig =
-      if darwinInput ? lib.darwinSystem then darwinInput.lib.darwinSystem
+      if darwinInput == null then
+        throw "meta.nix-darwin must be set when deploying darwin nodes. Add your nix-darwin flake input to meta.nix-darwin."
+      else if darwinInput ? lib.darwinSystem then darwinInput.lib.darwinSystem
       else if darwinInput ? darwinSystem then darwinInput.darwinSystem
-      else throw "Could not find darwinSystem in meta.nix-darwin. Expected nix-darwin flake input.";
+      else throw "Could not find darwinSystem in meta.nix-darwin. Expected a nix-darwin flake input.";
 
     # Darwin-specific nixpkgs module
-    nixpkgsModule = { config, lib, ... }: let
+    nixpkgsModule = { lib, ... }: let
       hasTypedConfig = lib.versionAtLeast lib.version "22.11pre";
     in {
       nixpkgs.overlays = lib.mkBefore npkgs.overlays;
       nixpkgs.config = if hasTypedConfig then lib.mkBefore npkgs.config else lib.mkOptionDefault npkgs.config;
     };
-
-    # The darwin defaults (if any)
-    darwinDefaults = hive.darwinDefaults or {};
 
   in evalConfig {
     inherit (npkgs.stdenv.hostPlatform) system;
@@ -220,17 +254,14 @@ let
       colmenaModules.assertionModule
       colmenaOptions.deploymentOptions
       hive.defaults
-      darwinDefaults
+      hive.darwinDefaults
     ] ++ configs;
-    specialArgs = {
-      inherit name;
-      nodes = uncheckedNodes;
-    } // hive.meta.specialArgs // (hive.meta.nodeSpecialArgs.${name} or {});
+    specialArgs = mkSpecialArgs name;
   };
 
   # Evaluate a node based on its system type
   evalNode = name: configs: let
-    systemType = getNodeSystemType name configs;
+    systemType = nodeSystemTypes.${name};
   in
     if systemType == "darwin" then evalDarwinNode name configs
     else evalNixOSNode name configs;
@@ -260,7 +291,7 @@ let
   # Get the toplevel/system output based on node system type
   # NixOS uses system.build.toplevel, darwin uses system directly
   getNodeToplevel = name: node: let
-    systemType = getNodeSystemType name (configsFor name);
+    systemType = nodeSystemTypes.${name};
   in
     if systemType == "darwin" then node.system
     else node.config.system.build.toplevel;

--- a/src/nix/hive/eval.nix
+++ b/src/nix/hive/eval.nix
@@ -15,7 +15,16 @@ let
     # containing configurations that will be applied to all
     # hosts.
     defaults = {};
+
+    # Darwin-specific defaults (only applied to darwin nodes)
+    darwinDefaults = {};
   };
+
+  # Check if a node is defined in darwinConfigurations (for auto-detection)
+  isDarwinFromFlake = name:
+    rawFlake != null &&
+    rawFlake.outputs ? darwinConfigurations &&
+    rawFlake.outputs.darwinConfigurations ? ${name};
 
 
   uncheckedHive = let
@@ -112,9 +121,23 @@ let
   in mkNixpkgs "meta.nixpkgs" nixpkgsConf;
 
   lib = nixpkgs.lib;
-  reservedNames = [ "defaults" "network" "meta" ];
+  reservedNames = [ "defaults" "darwinDefaults" "network" "meta" ];
 
-  evalNode = name: configs: let
+  # Determine system type for a node
+  # Priority: 1. Explicit deployment.systemType, 2. Auto-detect from darwinConfigurations
+  getNodeSystemType = name: configs: let
+    # Find if any config sets deployment.systemType
+    explicitType = lib.findFirst
+      (c: c ? deployment && c.deployment ? systemType)
+      null
+      configs;
+  in
+    if explicitType != null then explicitType.deployment.systemType
+    else if isDarwinFromFlake name then "darwin"
+    else "nixos";
+
+  # Evaluate a NixOS node
+  evalNixOSNode = name: configs: let
     npkgs =
       if hasAttr name hive.meta.nodeNixpkgs
       then mkNixpkgs "meta.nodeNixpkgs.${name}" hive.meta.nodeNixpkgs.${name}
@@ -157,6 +180,61 @@ let
     } // hive.meta.specialArgs // (hive.meta.nodeSpecialArgs.${name} or {});
   };
 
+  # Evaluate a darwin node
+  evalDarwinNode = name: configs: let
+    npkgs =
+      if hasAttr name hive.meta.nodeNixpkgs
+      then mkNixpkgs "meta.nodeNixpkgs.${name}" hive.meta.nodeNixpkgs.${name}
+      else nixpkgs;
+
+    # Get the nix-darwin input from meta
+    darwinInput = hive.meta.nix-darwin or null;
+    # Assert that nix-darwin is provided (assigns true to _ if assertion passes)
+    _ = assert lib.assertMsg (darwinInput != null)
+      "meta.nix-darwin must be set when deploying darwin nodes. Add your nix-darwin flake input to meta.nix-darwin.";
+      true;
+
+    # Use darwin's eval-config
+    # nix-darwin provides darwinSystem in lib or as a flake output
+    evalConfig =
+      if darwinInput ? lib.darwinSystem then darwinInput.lib.darwinSystem
+      else if darwinInput ? darwinSystem then darwinInput.darwinSystem
+      else throw "Could not find darwinSystem in meta.nix-darwin. Expected nix-darwin flake input.";
+
+    # Darwin-specific nixpkgs module
+    nixpkgsModule = { config, lib, ... }: let
+      hasTypedConfig = lib.versionAtLeast lib.version "22.11pre";
+    in {
+      nixpkgs.overlays = lib.mkBefore npkgs.overlays;
+      nixpkgs.config = if hasTypedConfig then lib.mkBefore npkgs.config else lib.mkOptionDefault npkgs.config;
+    };
+
+    # The darwin defaults (if any)
+    darwinDefaults = hive.darwinDefaults or {};
+
+  in evalConfig {
+    inherit (npkgs.stdenv.hostPlatform) system;
+
+    modules = [
+      nixpkgsModule
+      colmenaModules.assertionModule
+      colmenaOptions.deploymentOptions
+      hive.defaults
+      darwinDefaults
+    ] ++ configs;
+    specialArgs = {
+      inherit name;
+      nodes = uncheckedNodes;
+    } // hive.meta.specialArgs // (hive.meta.nodeSpecialArgs.${name} or {});
+  };
+
+  # Evaluate a node based on its system type
+  evalNode = name: configs: let
+    systemType = getNodeSystemType name configs;
+  in
+    if systemType == "darwin" then evalDarwinNode name configs
+    else evalNixOSNode name configs;
+
   nodeNames = filter (name: ! elem name reservedNames) (attrNames hive);
 
   # Used as the `nodes` argument in modules. We skip recursive type checking
@@ -179,12 +257,20 @@ let
     "allowApplyAll"
   ];
 
+  # Get the toplevel/system output based on node system type
+  # NixOS uses system.build.toplevel, darwin uses system directly
+  getNodeToplevel = name: node: let
+    systemType = getNodeSystemType name (configsFor name);
+  in
+    if systemType == "darwin" then node.system
+    else node.config.system.build.toplevel;
+
 in rec {
   # Exported attributes
   __schema = "v0.5";
 
   nodes = listToAttrs (map (name: { inherit name; value = evalNode name (configsFor name); }) nodeNames);
-  toplevel =         lib.mapAttrs (_: v: v.config.system.build.toplevel) nodes;
+  toplevel =         lib.mapAttrs getNodeToplevel nodes;
   deploymentConfig = lib.mapAttrs (_: v: v.config.deployment)            nodes;
   deploymentConfigSelected = names: lib.filterAttrs (name: _: elem name names) deploymentConfig;
   evalSelected =             names: lib.filterAttrs (name: _: elem name names) toplevel;

--- a/src/nix/hive/options.nix
+++ b/src/nix/hive/options.nix
@@ -213,6 +213,19 @@ with builtins; rec {
           type = types.listOf types.str;
           default = [];
         };
+        systemType = lib.mkOption {
+          description = ''
+            The type of system to deploy.
+
+            - "nixos" (default): NixOS system using switch-to-configuration for activation.
+            - "darwin": macOS system using nix-darwin activation scripts.
+
+            When using flakes, this is automatically detected from darwinConfigurations
+            if not explicitly set.
+          '';
+          type = types.enum [ "nixos" "darwin" ];
+          default = "nixos";
+        };
       };
     };
   };
@@ -308,6 +321,26 @@ with builtins; rec {
         '';
         default = true;
         type = types.bool;
+      };
+      nix-darwin = lib.mkOption {
+        description = ''
+          The nix-darwin flake input for evaluating darwin nodes.
+
+          This must be set when deploying to darwin nodes with Flakes.
+          For example:
+
+            {
+              inputs.nix-darwin.url = "github:LnL7/nix-darwin";
+              outputs = { nixpkgs, nix-darwin, ... }: {
+                colmena = {
+                  meta.nix-darwin = nix-darwin;
+                  # ...
+                };
+              };
+            }
+        '';
+        type = types.nullOr types.unspecified;
+        default = null;
       };
     };
   };

--- a/src/nix/hive/options.nix
+++ b/src/nix/hive/options.nix
@@ -339,7 +339,7 @@ with builtins; rec {
               };
             }
         '';
-        type = types.nullOr types.unspecified;
+        type = types.unspecified;
         default = null;
       };
     };

--- a/src/nix/hive/tests/mod.rs
+++ b/src/nix/hive/tests/mod.rs
@@ -2,6 +2,7 @@
 
 use super::*;
 
+use crate::nix::SystemType;
 use std::collections::HashSet;
 use std::fs;
 use std::hash::Hash;
@@ -672,4 +673,53 @@ fn test_hive_get_meta() {
     eprintln!("{:?}", eval);
 
     assert!(!eval.allow_apply_all);
+}
+
+#[test]
+fn test_system_type_darwin() {
+    // deployment.systemType = "darwin" should be accepted
+    TempHive::valid(
+        r#"
+      {
+        test = { ... }: {
+          boot.isContainer = true;
+          deployment.systemType = "darwin";
+        };
+      }
+    "#,
+    );
+}
+
+#[test]
+fn test_system_type_nixos_default() {
+    // systemType defaults to "nixos"
+    let hive = TempHive::new(
+        r#"
+      {
+        test = { ... }: {
+          boot.isContainer = true;
+        };
+      }
+    "#,
+    );
+    let nodes = block_on(hive.deployment_info()).unwrap();
+    let test = &nodes[&node!("test")];
+    assert_eq!(SystemType::NixOS, test.system_type());
+}
+
+#[test]
+fn test_system_type_darwin_parsed() {
+    let hive = TempHive::new(
+        r#"
+      {
+        test = { ... }: {
+          boot.isContainer = true;
+          deployment.systemType = "darwin";
+        };
+      }
+    "#,
+    );
+    let nodes = block_on(hive.deployment_info()).unwrap();
+    let test = &nodes[&node!("test")];
+    assert_eq!(SystemType::Darwin, test.system_type());
 }

--- a/src/nix/hive/tests/mod.rs
+++ b/src/nix/hive/tests/mod.rs
@@ -675,14 +675,58 @@ fn test_hive_get_meta() {
     assert!(!eval.allow_apply_all);
 }
 
+/// Builds a hive whose `meta.nix-darwin` is a minimal stub — just enough for a
+/// darwin node to evaluate its `deployment` config in tests without a real
+/// nix-darwin input. It mimics `darwinSystem` closely enough to resolve
+/// `config.deployment` (all `deployment_info` reads) by running the module
+/// system with type checking disabled. `{body}` is the node's config expression.
+fn darwin_hive_with(body: &str) -> String {
+    format!(
+        r#"
+      {{
+        meta.nix-darwin.darwinSystem = {{ modules, specialArgs, ... }}:
+          (import <nixpkgs/lib>).evalModules {{
+            modules = modules ++ [ {{ _module.check = false; }} ];
+            inherit specialArgs;
+          }};
+        test = {body};
+      }}
+    "#
+    )
+}
+
 #[test]
 fn test_system_type_darwin() {
-    // deployment.systemType = "darwin" should be accepted
-    TempHive::valid(
+    // deployment.systemType = "darwin" (function-form module) should be accepted
+    // and routed to the darwin evaluator (here backed by the stub above).
+    TempHive::valid(&darwin_hive_with(
+        r#"{ ... }: {
+          deployment.systemType = "darwin";
+        }"#,
+    ));
+}
+
+#[test]
+fn test_system_type_darwin_attrset() {
+    // An attribute-set node (the form used in the PR docs) is detected too.
+    TempHive::valid(&darwin_hive_with(
+        r#"{
+          deployment.systemType = "darwin";
+        }"#,
+    ));
+}
+
+#[test]
+fn test_system_type_darwin_requires_nix_darwin() {
+    // Regression test for the eval-branch selection: a darwin node written as a
+    // module *function* must be routed to the darwin evaluator. Previously such
+    // configs were misdetected as NixOS (attribute introspection cannot see into
+    // a function), so this hive would have evaluated successfully as NixOS.
+    // Without meta.nix-darwin, the darwin evaluator must fail with a clear error.
+    TempHive::invalid(
         r#"
       {
         test = { ... }: {
-          boot.isContainer = true;
           deployment.systemType = "darwin";
         };
       }
@@ -709,16 +753,11 @@ fn test_system_type_nixos_default() {
 
 #[test]
 fn test_system_type_darwin_parsed() {
-    let hive = TempHive::new(
-        r#"
-      {
-        test = { ... }: {
-          boot.isContainer = true;
+    let hive = TempHive::new(&darwin_hive_with(
+        r#"{ ... }: {
           deployment.systemType = "darwin";
-        };
-      }
-    "#,
-    );
+        }"#,
+    ));
     let nodes = block_on(hive.deployment_info()).unwrap();
     let test = &nodes[&node!("test")];
     assert_eq!(SystemType::Darwin, test.system_type());

--- a/src/nix/host/local.rs
+++ b/src/nix/host/local.rs
@@ -8,7 +8,9 @@ use tokio::process::Command;
 use super::{CopyDirection, CopyOptions, Host, key_uploader};
 use crate::error::{ColmenaError, ColmenaResult};
 use crate::job::JobHandle;
-use crate::nix::{CURRENT_PROFILE, Goal, Key, NixFlags, Profile, SYSTEM_PROFILE, StorePath};
+use crate::nix::{
+    CURRENT_PROFILE, Goal, Key, NixFlags, Profile, SYSTEM_PROFILE, StorePath, SystemType,
+};
 use crate::util::{CommandExecution, CommandExt};
 
 /// The local machine running Colmena.
@@ -78,8 +80,13 @@ impl Host for Local {
         Ok(())
     }
 
-    async fn activate(&mut self, profile: &Profile, goal: Goal) -> ColmenaResult<()> {
+    async fn activate(&mut self, profile: &Profile, goal: Goal, system_type: SystemType) -> ColmenaResult<()> {
         if !goal.requires_activation() {
+            return Err(ColmenaError::Unsupported);
+        }
+
+        // Check if this goal is supported for Darwin
+        if system_type.is_darwin() && !goal.supported_on_darwin() {
             return Err(ColmenaError::Unsupported);
         }
 
@@ -91,7 +98,8 @@ impl Host for Local {
         }
 
         let command = {
-            let activation_command = profile.activation_command(goal).unwrap();
+            let activation_command = profile.activation_command(goal, system_type)
+                .ok_or(ColmenaError::Unsupported)?;
             self.make_privileged_command(&activation_command)
         };
 

--- a/src/nix/host/local.rs
+++ b/src/nix/host/local.rs
@@ -80,7 +80,12 @@ impl Host for Local {
         Ok(())
     }
 
-    async fn activate(&mut self, profile: &Profile, goal: Goal, system_type: SystemType) -> ColmenaResult<()> {
+    async fn activate(
+        &mut self,
+        profile: &Profile,
+        goal: Goal,
+        system_type: SystemType,
+    ) -> ColmenaResult<()> {
         if !goal.requires_activation() {
             return Err(ColmenaError::Unsupported);
         }
@@ -98,7 +103,8 @@ impl Host for Local {
         }
 
         let command = {
-            let activation_command = profile.activation_command(goal, system_type)
+            let activation_command = profile
+                .activation_command(goal, system_type)
                 .ok_or(ColmenaError::Unsupported)?;
             self.make_privileged_command(&activation_command)
         };

--- a/src/nix/host/local.rs
+++ b/src/nix/host/local.rs
@@ -9,9 +9,24 @@ use super::{CopyDirection, CopyOptions, Host, key_uploader};
 use crate::error::{ColmenaError, ColmenaResult};
 use crate::job::JobHandle;
 use crate::nix::{
-    CURRENT_PROFILE, Goal, Key, NixFlags, Profile, SYSTEM_PROFILE, StorePath, SystemType,
+    CURRENT_PROFILE, DARWIN_NIX_BIN_PATH, Goal, Key, NixFlags, Profile, SYSTEM_PROFILE, StorePath,
+    SystemType,
 };
 use crate::util::{CommandExecution, CommandExt};
+
+/// Resolves a nix binary name to an absolute path when running on macOS.
+///
+/// The [`Local`] host always executes on the machine running Colmena, so the
+/// relevant OS is the compile target. On macOS, root's PATH (and sudo's
+/// `secure_path`) excludes the nix profile bin dir, so we must use an absolute
+/// path; on other platforms the bare name is resolved via PATH as usual.
+fn local_nix_bin(name: &str) -> String {
+    if cfg!(target_os = "macos") {
+        format!("{DARWIN_NIX_BIN_PATH}/{name}")
+    } else {
+        name.to_string()
+    }
+}
 
 /// The local machine running Colmena.
 ///
@@ -46,7 +61,7 @@ impl Host for Local {
     }
 
     async fn realize_remote(&mut self, derivation: &StorePath) -> ColmenaResult<Vec<StorePath>> {
-        let mut command = Command::new("nix-store");
+        let mut command = Command::new(local_nix_bin("nix-store"));
 
         command.args(self.nix_options.to_nix_store_args());
         command
@@ -97,9 +112,16 @@ impl Host for Local {
 
         if goal.should_switch_profile() {
             let path = profile.as_path().to_str().unwrap();
-            self.make_privileged_command(&["nix-env", "--profile", SYSTEM_PROFILE, "--set", path])
-                .passthrough()
-                .await?;
+            let nix_env = local_nix_bin("nix-env");
+            self.make_privileged_command(&[
+                nix_env.as_str(),
+                "--profile",
+                SYSTEM_PROFILE,
+                "--set",
+                path,
+            ])
+            .passthrough()
+            .await?;
         }
 
         let command = {
@@ -117,8 +139,10 @@ impl Host for Local {
     }
 
     async fn get_current_system_profile(&mut self) -> ColmenaResult<Profile> {
+        // `readlink -f` (not GNU-only `-e`) so this also works on macOS/BSD.
+        // CURRENT_PROFILE is always a valid symlink on a live system.
         let paths = Command::new("readlink")
-            .args(["-e", CURRENT_PROFILE])
+            .args(["-f", CURRENT_PROFILE])
             .capture_output()
             .await?;
 
@@ -133,12 +157,17 @@ impl Host for Local {
     }
 
     async fn get_main_system_profile(&mut self) -> ColmenaResult<Profile> {
+        // `readlink -f` for GNU/BSD portability. The `[ -e ]` guard preserves
+        // the "final target must exist" semantics of the old `readlink -e`
+        // fallback: a bare `-f` prints a non-existent path (exit 0) under GNU,
+        // which would wrongly suppress the fallback to CURRENT_PROFILE.
         let paths = Command::new("sh")
             .args([
                 "-c",
                 &format!(
-                    "readlink -e {} || readlink -e {}",
-                    SYSTEM_PROFILE, CURRENT_PROFILE
+                    "if [ -e {sys} ]; then readlink -f {sys}; else readlink -f {cur}; fi",
+                    sys = SYSTEM_PROFILE,
+                    cur = CURRENT_PROFILE
                 ),
             ])
             .capture_output()

--- a/src/nix/host/local.rs
+++ b/src/nix/host/local.rs
@@ -8,7 +8,9 @@ use tokio::process::Command;
 use super::{key_uploader, CopyDirection, CopyOptions, Host};
 use crate::error::{ColmenaError, ColmenaResult};
 use crate::job::JobHandle;
-use crate::nix::{Goal, Key, NixFlags, Profile, StorePath, SystemType, CURRENT_PROFILE, SYSTEM_PROFILE};
+use crate::nix::{
+    Goal, Key, NixFlags, Profile, StorePath, SystemType, CURRENT_PROFILE, SYSTEM_PROFILE,
+};
 use crate::util::{CommandExecution, CommandExt};
 
 /// The local machine running Colmena.
@@ -78,7 +80,12 @@ impl Host for Local {
         Ok(())
     }
 
-    async fn activate(&mut self, profile: &Profile, goal: Goal, system_type: SystemType) -> ColmenaResult<()> {
+    async fn activate(
+        &mut self,
+        profile: &Profile,
+        goal: Goal,
+        system_type: SystemType,
+    ) -> ColmenaResult<()> {
         if !goal.requires_activation() {
             return Err(ColmenaError::Unsupported);
         }
@@ -96,7 +103,8 @@ impl Host for Local {
         }
 
         let command = {
-            let activation_command = profile.activation_command(goal, system_type)
+            let activation_command = profile
+                .activation_command(goal, system_type)
                 .ok_or(ColmenaError::Unsupported)?;
             self.make_privileged_command(&activation_command)
         };

--- a/src/nix/host/local.rs
+++ b/src/nix/host/local.rs
@@ -8,7 +8,7 @@ use tokio::process::Command;
 use super::{key_uploader, CopyDirection, CopyOptions, Host};
 use crate::error::{ColmenaError, ColmenaResult};
 use crate::job::JobHandle;
-use crate::nix::{Goal, Key, NixFlags, Profile, StorePath, CURRENT_PROFILE, SYSTEM_PROFILE};
+use crate::nix::{Goal, Key, NixFlags, Profile, StorePath, SystemType, CURRENT_PROFILE, SYSTEM_PROFILE};
 use crate::util::{CommandExecution, CommandExt};
 
 /// The local machine running Colmena.
@@ -78,8 +78,13 @@ impl Host for Local {
         Ok(())
     }
 
-    async fn activate(&mut self, profile: &Profile, goal: Goal) -> ColmenaResult<()> {
+    async fn activate(&mut self, profile: &Profile, goal: Goal, system_type: SystemType) -> ColmenaResult<()> {
         if !goal.requires_activation() {
+            return Err(ColmenaError::Unsupported);
+        }
+
+        // Check if this goal is supported for Darwin
+        if system_type.is_darwin() && !goal.supported_on_darwin() {
             return Err(ColmenaError::Unsupported);
         }
 
@@ -91,7 +96,8 @@ impl Host for Local {
         }
 
         let command = {
-            let activation_command = profile.activation_command(goal).unwrap();
+            let activation_command = profile.activation_command(goal, system_type)
+                .ok_or(ColmenaError::Unsupported)?;
             self.make_privileged_command(&activation_command)
         };
 

--- a/src/nix/host/mod.rs
+++ b/src/nix/host/mod.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use async_trait::async_trait;
 
-use super::{Goal, Key, Profile, StorePath};
+use super::{Goal, Key, Profile, StorePath, SystemType};
 use crate::error::{ColmenaError, ColmenaResult};
 use crate::job::JobHandle;
 
@@ -34,6 +34,9 @@ pub struct RebootOptions {
 
     /// New system profile to expect upon reboot.
     new_profile: Option<Profile>,
+
+    /// System type (for platform-specific boot ID detection).
+    system_type: SystemType,
 }
 
 impl Default for CopyOptions {
@@ -68,6 +71,7 @@ impl Default for RebootOptions {
         Self {
             wait_for_boot: true,
             new_profile: None,
+            system_type: SystemType::default(),
         }
     }
 }
@@ -82,9 +86,18 @@ impl RebootOptions {
         self.new_profile = profile;
         self
     }
+
+    pub fn system_type(mut self, val: SystemType) -> Self {
+        self.system_type = val;
+        self
+    }
+
+    pub fn get_system_type(&self) -> SystemType {
+        self.system_type
+    }
 }
 
-/// A Nix(OS) host.
+/// A Nix(OS)/nix-darwin host.
 ///
 /// The underlying implementation must be Send and Sync.
 #[async_trait]
@@ -128,6 +141,7 @@ pub trait Host: Send + Sync + std::fmt::Debug {
         profile: &Profile,
         goal: Goal,
         copy_options: CopyOptions,
+        system_type: SystemType,
     ) -> ColmenaResult<()> {
         self.copy_closure(
             profile.as_store_path(),
@@ -137,7 +151,7 @@ pub trait Host: Send + Sync + std::fmt::Debug {
         .await?;
 
         if goal.requires_activation() {
-            self.activate(profile, goal).await?;
+            self.activate(profile, goal, system_type).await?;
         }
 
         Ok(())
@@ -167,11 +181,11 @@ pub trait Host: Send + Sync + std::fmt::Debug {
     /// to `/run/current-system` if it doesn't exist.
     async fn get_main_system_profile(&mut self) -> ColmenaResult<Profile>;
 
-    /// Activates a system profile on the host, if it runs NixOS.
+    /// Activates a system profile on the host (NixOS or darwin).
     ///
     /// The profile must already exist on the host. You should probably use deploy instead.
     #[allow(unused_variables)]
-    async fn activate(&mut self, profile: &Profile, goal: Goal) -> ColmenaResult<()> {
+    async fn activate(&mut self, profile: &Profile, goal: Goal, system_type: SystemType) -> ColmenaResult<()> {
         Err(ColmenaError::Unsupported)
     }
 

--- a/src/nix/host/mod.rs
+++ b/src/nix/host/mod.rs
@@ -185,7 +185,12 @@ pub trait Host: Send + Sync + std::fmt::Debug {
     ///
     /// The profile must already exist on the host. You should probably use deploy instead.
     #[allow(unused_variables)]
-    async fn activate(&mut self, profile: &Profile, goal: Goal, system_type: SystemType) -> ColmenaResult<()> {
+    async fn activate(
+        &mut self,
+        profile: &Profile,
+        goal: Goal,
+        system_type: SystemType,
+    ) -> ColmenaResult<()> {
         Err(ColmenaError::Unsupported)
     }
 

--- a/src/nix/host/mod.rs
+++ b/src/nix/host/mod.rs
@@ -91,10 +91,6 @@ impl RebootOptions {
         self.system_type = val;
         self
     }
-
-    pub fn get_system_type(&self) -> SystemType {
-        self.system_type
-    }
 }
 
 /// A Nix(OS)/nix-darwin host.

--- a/src/nix/host/ssh.rs
+++ b/src/nix/host/ssh.rs
@@ -100,7 +100,12 @@ impl Host for Ssh {
         Ok(())
     }
 
-    async fn activate(&mut self, profile: &Profile, goal: Goal, system_type: SystemType) -> ColmenaResult<()> {
+    async fn activate(
+        &mut self,
+        profile: &Profile,
+        goal: Goal,
+        system_type: SystemType,
+    ) -> ColmenaResult<()> {
         if !goal.requires_activation() {
             return Err(ColmenaError::Unsupported);
         }
@@ -123,7 +128,8 @@ impl Host for Ssh {
         }
 
         // Get the activation command based on system type
-        let activation_command = profile.activation_command(goal, system_type)
+        let activation_command = profile
+            .activation_command(goal, system_type)
             .ok_or(ColmenaError::Unsupported)?;
         let v: Vec<&str> = activation_command.iter().map(|s| &**s).collect();
         let command = self.ssh(&v);

--- a/src/nix/host/ssh.rs
+++ b/src/nix/host/ssh.rs
@@ -69,8 +69,14 @@ impl Host for Ssh {
     }
 
     async fn realize_remote(&mut self, derivation: &StorePath) -> ColmenaResult<Vec<StorePath>> {
+        // Use full path for nix-store on Darwin since root's PATH doesn't include nix binaries
+        let nix_store = if self.system_type.is_darwin() {
+            format!("{}/nix-store", DARWIN_NIX_BIN_PATH)
+        } else {
+            "nix-store".to_string()
+        };
         let command = self.ssh(&[
-            "nix-store",
+            &nix_store,
             "--no-gc-warning",
             "--realise",
             derivation.as_path().to_str().unwrap(),

--- a/src/nix/host/ssh.rs
+++ b/src/nix/host/ssh.rs
@@ -12,8 +12,14 @@ use tokio::time::sleep;
 use super::{CopyDirection, CopyOptions, Host, RebootOptions, key_uploader};
 use crate::error::{ColmenaError, ColmenaResult};
 use crate::job::JobHandle;
-use crate::nix::{CURRENT_PROFILE, Goal, Key, Profile, SYSTEM_PROFILE, StorePath};
+use crate::nix::{CURRENT_PROFILE, Goal, Key, Profile, SYSTEM_PROFILE, StorePath, SystemType};
 use crate::util::{CommandExecution, CommandExt};
+
+/// Default nix bin directory on macOS.
+/// Root's PATH on macOS doesn't include nix binaries by default
+/// (/usr/bin:/bin:/usr/sbin:/sbin). This is the canonical path that
+/// both /var/root/.nix-profile and /nix/var/nix/profiles/default symlink to.
+const DARWIN_NIX_BIN_PATH: &str = "/nix/var/nix/profiles/default/bin";
 
 /// A remote machine connected over SSH.
 #[derive(Debug)]
@@ -38,6 +44,10 @@ pub struct Ssh {
 
     /// Whether to use the experimental `nix copy` command.
     use_nix3_copy: bool,
+
+    /// The system type (NixOS or Darwin).
+    /// Used to handle platform-specific differences like nix-daemon path on macOS.
+    system_type: SystemType,
 
     job: Option<JobHandle>,
 }
@@ -90,18 +100,31 @@ impl Host for Ssh {
         Ok(())
     }
 
-    async fn activate(&mut self, profile: &Profile, goal: Goal) -> ColmenaResult<()> {
+    async fn activate(&mut self, profile: &Profile, goal: Goal, system_type: SystemType) -> ColmenaResult<()> {
         if !goal.requires_activation() {
+            return Err(ColmenaError::Unsupported);
+        }
+
+        // Check if this goal is supported for Darwin
+        if system_type.is_darwin() && !goal.supported_on_darwin() {
             return Err(ColmenaError::Unsupported);
         }
 
         if goal.should_switch_profile() {
             let path = profile.as_path().to_str().unwrap();
-            let set_profile = self.ssh(&["nix-env", "--profile", SYSTEM_PROFILE, "--set", path]);
+            // Use full path for nix-env on Darwin since root's PATH doesn't include nix binaries
+            let nix_env = if system_type.is_darwin() {
+                format!("{}/nix-env", DARWIN_NIX_BIN_PATH)
+            } else {
+                "nix-env".to_string()
+            };
+            let set_profile = self.ssh(&[&nix_env, "--profile", SYSTEM_PROFILE, "--set", path]);
             self.run_command(set_profile).await?;
         }
 
-        let activation_command = profile.activation_command(goal).unwrap();
+        // Get the activation command based on system type
+        let activation_command = profile.activation_command(goal, system_type)
+            .ok_or(ColmenaError::Unsupported)?;
         let v: Vec<&str> = activation_command.iter().map(|s| &**s).collect();
         let command = self.ssh(&v);
         self.run_command(command).await
@@ -151,7 +174,8 @@ impl Host for Ssh {
             return self.initate_reboot().await;
         }
 
-        let old_id = self.get_boot_id().await?;
+        let system_type = options.get_system_type();
+        let old_id = self.get_boot_id(system_type).await?;
 
         self.initate_reboot().await?;
 
@@ -162,7 +186,7 @@ impl Host for Ssh {
         // Wait for node to come back up
         loop {
             // Ignore errors while waiting
-            if let Ok(new_id) = self.get_boot_id().await
+            if let Ok(new_id) = self.get_boot_id(system_type).await
                 && new_id != old_id
             {
                 break;
@@ -194,6 +218,7 @@ impl Ssh {
             privilege_escalation_command: Vec::new(),
             extra_ssh_options: Vec::new(),
             use_nix3_copy: false,
+            system_type: SystemType::default(),
             job: None,
         }
     }
@@ -216,6 +241,10 @@ impl Ssh {
 
     pub fn set_use_nix3_copy(&mut self, enable: bool) {
         self.use_nix3_copy = enable;
+    }
+
+    pub fn set_system_type(&mut self, system_type: SystemType) {
+        self.system_type = system_type;
     }
 
     pub fn upcast(self) -> Box<dyn Host> {
@@ -299,10 +328,24 @@ impl Ssh {
                 }
             }
 
+            // Build the store URI with appropriate query parameters
+            // For darwin, we need to specify the remote-program because root's PATH
+            // on macOS doesn't include nix binaries by default
             let mut store_uri = format!("ssh-ng://{}", self.ssh_target());
-            if options.gzip {
-                store_uri += "?compress=true";
+            let mut query_params = Vec::new();
+
+            if self.system_type.is_darwin() {
+                query_params.push(format!("remote-program={}/nix-daemon", DARWIN_NIX_BIN_PATH));
             }
+
+            if options.gzip {
+                query_params.push("compress=true".to_string());
+            }
+
+            if !query_params.is_empty() {
+                store_uri = format!("{}?{}", store_uri, query_params.join("&"));
+            }
+
             command.arg(store_uri);
 
             command.arg(path.as_path());
@@ -395,11 +438,16 @@ impl Ssh {
     }
 
     /// Returns the current Boot ID.
-    async fn get_boot_id(&mut self) -> ColmenaResult<BootId> {
-        let boot_id = self
-            .ssh(&["cat", "/proc/sys/kernel/random/boot_id"])
-            .capture_output()
-            .await?;
+    ///
+    /// For NixOS, reads from /proc/sys/kernel/random/boot_id.
+    /// For Darwin, uses sysctl kern.bootsessionuuid.
+    async fn get_boot_id(&mut self, system_type: SystemType) -> ColmenaResult<BootId> {
+        let command = match system_type {
+            SystemType::NixOS => vec!["cat", "/proc/sys/kernel/random/boot_id"],
+            SystemType::Darwin => vec!["sysctl", "-n", "kern.bootsessionuuid"],
+        };
+
+        let boot_id = self.ssh(&command).capture_output().await?;
 
         Ok(BootId(boot_id))
     }

--- a/src/nix/host/ssh.rs
+++ b/src/nix/host/ssh.rs
@@ -12,14 +12,22 @@ use tokio::time::sleep;
 use super::{CopyDirection, CopyOptions, Host, RebootOptions, key_uploader};
 use crate::error::{ColmenaError, ColmenaResult};
 use crate::job::JobHandle;
-use crate::nix::{CURRENT_PROFILE, Goal, Key, Profile, SYSTEM_PROFILE, StorePath, SystemType};
+use crate::nix::{
+    CURRENT_PROFILE, DARWIN_NIX_BIN_PATH, Goal, Key, Profile, SYSTEM_PROFILE, StorePath, SystemType,
+};
 use crate::util::{CommandExecution, CommandExt};
 
-/// Default nix bin directory on macOS.
-/// Root's PATH on macOS doesn't include nix binaries by default
-/// (/usr/bin:/bin:/usr/sbin:/sbin). This is the canonical path that
-/// both /var/root/.nix-profile and /nix/var/nix/profiles/default symlink to.
-const DARWIN_NIX_BIN_PATH: &str = "/nix/var/nix/profiles/default/bin";
+/// Resolves a nix binary name to run on the remote target.
+///
+/// On darwin, root's PATH doesn't include the nix binaries, so we use an
+/// absolute path; elsewhere the bare name is resolved via the remote PATH.
+fn remote_nix_bin(system_type: SystemType, name: &str) -> String {
+    if system_type.is_darwin() {
+        format!("{DARWIN_NIX_BIN_PATH}/{name}")
+    } else {
+        name.to_string()
+    }
+}
 
 /// A remote machine connected over SSH.
 #[derive(Debug)]
@@ -69,12 +77,7 @@ impl Host for Ssh {
     }
 
     async fn realize_remote(&mut self, derivation: &StorePath) -> ColmenaResult<Vec<StorePath>> {
-        // Use full path for nix-store on Darwin since root's PATH doesn't include nix binaries
-        let nix_store = if self.system_type.is_darwin() {
-            format!("{}/nix-store", DARWIN_NIX_BIN_PATH)
-        } else {
-            "nix-store".to_string()
-        };
+        let nix_store = remote_nix_bin(self.system_type, "nix-store");
         let command = self.ssh(&[
             &nix_store,
             "--no-gc-warning",
@@ -123,12 +126,7 @@ impl Host for Ssh {
 
         if goal.should_switch_profile() {
             let path = profile.as_path().to_str().unwrap();
-            // Use full path for nix-env on Darwin since root's PATH doesn't include nix binaries
-            let nix_env = if system_type.is_darwin() {
-                format!("{}/nix-env", DARWIN_NIX_BIN_PATH)
-            } else {
-                "nix-env".to_string()
-            };
+            let nix_env = remote_nix_bin(system_type, "nix-env");
             let set_profile = self.ssh(&[&nix_env, "--profile", SYSTEM_PROFILE, "--set", path]);
             self.run_command(set_profile).await?;
         }
@@ -143,8 +141,10 @@ impl Host for Ssh {
     }
 
     async fn get_current_system_profile(&mut self) -> ColmenaResult<Profile> {
+        // `readlink -f` (not GNU-only `-e`) so this also works on macOS/BSD
+        // targets. CURRENT_PROFILE is always a valid symlink on a live system.
         let paths = self
-            .ssh(&["readlink", "-e", CURRENT_PROFILE])
+            .ssh(&["readlink", "-f", CURRENT_PROFILE])
             .capture_output()
             .await?;
 
@@ -159,9 +159,14 @@ impl Host for Ssh {
     }
 
     async fn get_main_system_profile(&mut self) -> ColmenaResult<Profile> {
+        // `readlink -f` for GNU/BSD portability. The `[ -e ]` guard preserves
+        // the "final target must exist" semantics of the old `readlink -e`
+        // fallback: a bare `-f` prints a non-existent path (exit 0) under GNU,
+        // which would wrongly suppress the fallback to CURRENT_PROFILE.
         let command = format!(
-            "\"readlink -e {} || readlink -e {}\"",
-            SYSTEM_PROFILE, CURRENT_PROFILE
+            "\"if [ -e {sys} ]; then readlink -f {sys}; else readlink -f {cur}; fi\"",
+            sys = SYSTEM_PROFILE,
+            cur = CURRENT_PROFILE
         );
 
         let paths = self.ssh(&["sh", "-c", &command]).capture_output().await?;
@@ -186,7 +191,7 @@ impl Host for Ssh {
             return self.initate_reboot().await;
         }
 
-        let system_type = options.get_system_type();
+        let system_type = options.system_type;
         let old_id = self.get_boot_id(system_type).await?;
 
         self.initate_reboot().await?;
@@ -308,7 +313,14 @@ impl Ssh {
         let ssh_options = self.ssh_options();
         let ssh_options_str = ssh_options.join(" ");
 
-        let mut command = if self.use_nix3_copy {
+        // Darwin must use `nix copy` (ssh-ng): the legacy `nix-copy-closure`
+        // binary runs `nix-store --serve` on the remote via the plain `ssh://`
+        // store and relies on the remote PATH, which lacks nix binaries for root
+        // on macOS. It has no way to point at a remote program, whereas the
+        // ssh-ng path below already injects `remote-program=.../nix-daemon`.
+        let use_nix3_copy = self.use_nix3_copy || self.system_type.is_darwin();
+
+        let mut command = if use_nix3_copy {
             // experimental `nix copy` command with ssh-ng://
             let mut command = Command::new("nix");
 
@@ -347,7 +359,7 @@ impl Ssh {
             let mut query_params = Vec::new();
 
             if self.system_type.is_darwin() {
-                query_params.push(format!("remote-program={}/nix-daemon", DARWIN_NIX_BIN_PATH));
+                query_params.push(format!("remote-program={DARWIN_NIX_BIN_PATH}/nix-daemon"));
             }
 
             if options.gzip {

--- a/src/nix/host/ssh.rs
+++ b/src/nix/host/ssh.rs
@@ -12,8 +12,14 @@ use tokio::time::sleep;
 use super::{key_uploader, CopyDirection, CopyOptions, Host, RebootOptions};
 use crate::error::{ColmenaError, ColmenaResult};
 use crate::job::JobHandle;
-use crate::nix::{Goal, Key, Profile, StorePath, CURRENT_PROFILE, SYSTEM_PROFILE};
+use crate::nix::{Goal, Key, Profile, StorePath, SystemType, CURRENT_PROFILE, SYSTEM_PROFILE};
 use crate::util::{CommandExecution, CommandExt};
+
+/// Default nix bin directory on macOS.
+/// Root's PATH on macOS doesn't include nix binaries by default
+/// (/usr/bin:/bin:/usr/sbin:/sbin). This is the canonical path that
+/// both /var/root/.nix-profile and /nix/var/nix/profiles/default symlink to.
+const DARWIN_NIX_BIN_PATH: &str = "/nix/var/nix/profiles/default/bin";
 
 /// A remote machine connected over SSH.
 #[derive(Debug)]
@@ -38,6 +44,10 @@ pub struct Ssh {
 
     /// Whether to use the experimental `nix copy` command.
     use_nix3_copy: bool,
+
+    /// The system type (NixOS or Darwin).
+    /// Used to handle platform-specific differences like nix-daemon path on macOS.
+    system_type: SystemType,
 
     job: Option<JobHandle>,
 }
@@ -90,18 +100,31 @@ impl Host for Ssh {
         Ok(())
     }
 
-    async fn activate(&mut self, profile: &Profile, goal: Goal) -> ColmenaResult<()> {
+    async fn activate(&mut self, profile: &Profile, goal: Goal, system_type: SystemType) -> ColmenaResult<()> {
         if !goal.requires_activation() {
+            return Err(ColmenaError::Unsupported);
+        }
+
+        // Check if this goal is supported for Darwin
+        if system_type.is_darwin() && !goal.supported_on_darwin() {
             return Err(ColmenaError::Unsupported);
         }
 
         if goal.should_switch_profile() {
             let path = profile.as_path().to_str().unwrap();
-            let set_profile = self.ssh(&["nix-env", "--profile", SYSTEM_PROFILE, "--set", path]);
+            // Use full path for nix-env on Darwin since root's PATH doesn't include nix binaries
+            let nix_env = if system_type.is_darwin() {
+                format!("{}/nix-env", DARWIN_NIX_BIN_PATH)
+            } else {
+                "nix-env".to_string()
+            };
+            let set_profile = self.ssh(&[&nix_env, "--profile", SYSTEM_PROFILE, "--set", path]);
             self.run_command(set_profile).await?;
         }
 
-        let activation_command = profile.activation_command(goal).unwrap();
+        // Get the activation command based on system type
+        let activation_command = profile.activation_command(goal, system_type)
+            .ok_or(ColmenaError::Unsupported)?;
         let v: Vec<&str> = activation_command.iter().map(|s| &**s).collect();
         let command = self.ssh(&v);
         self.run_command(command).await
@@ -151,7 +174,8 @@ impl Host for Ssh {
             return self.initate_reboot().await;
         }
 
-        let old_id = self.get_boot_id().await?;
+        let system_type = options.get_system_type();
+        let old_id = self.get_boot_id(system_type).await?;
 
         self.initate_reboot().await?;
 
@@ -162,7 +186,7 @@ impl Host for Ssh {
         // Wait for node to come back up
         loop {
             // Ignore errors while waiting
-            if let Ok(new_id) = self.get_boot_id().await {
+            if let Ok(new_id) = self.get_boot_id(system_type).await {
                 if new_id != old_id {
                     break;
                 }
@@ -194,6 +218,7 @@ impl Ssh {
             privilege_escalation_command: Vec::new(),
             extra_ssh_options: Vec::new(),
             use_nix3_copy: false,
+            system_type: SystemType::default(),
             job: None,
         }
     }
@@ -216,6 +241,10 @@ impl Ssh {
 
     pub fn set_use_nix3_copy(&mut self, enable: bool) {
         self.use_nix3_copy = enable;
+    }
+
+    pub fn set_system_type(&mut self, system_type: SystemType) {
+        self.system_type = system_type;
     }
 
     pub fn upcast(self) -> Box<dyn Host> {
@@ -299,10 +328,24 @@ impl Ssh {
                 }
             }
 
+            // Build the store URI with appropriate query parameters
+            // For darwin, we need to specify the remote-program because root's PATH
+            // on macOS doesn't include nix binaries by default
             let mut store_uri = format!("ssh-ng://{}", self.ssh_target());
-            if options.gzip {
-                store_uri += "?compress=true";
+            let mut query_params = Vec::new();
+
+            if self.system_type.is_darwin() {
+                query_params.push(format!("remote-program={}/nix-daemon", DARWIN_NIX_BIN_PATH));
             }
+
+            if options.gzip {
+                query_params.push("compress=true".to_string());
+            }
+
+            if !query_params.is_empty() {
+                store_uri = format!("{}?{}", store_uri, query_params.join("&"));
+            }
+
             command.arg(store_uri);
 
             command.arg(path.as_path());
@@ -395,11 +438,16 @@ impl Ssh {
     }
 
     /// Returns the current Boot ID.
-    async fn get_boot_id(&mut self) -> ColmenaResult<BootId> {
-        let boot_id = self
-            .ssh(&["cat", "/proc/sys/kernel/random/boot_id"])
-            .capture_output()
-            .await?;
+    ///
+    /// For NixOS, reads from /proc/sys/kernel/random/boot_id.
+    /// For Darwin, uses sysctl kern.bootsessionuuid.
+    async fn get_boot_id(&mut self, system_type: SystemType) -> ColmenaResult<BootId> {
+        let command = match system_type {
+            SystemType::NixOS => vec!["cat", "/proc/sys/kernel/random/boot_id"],
+            SystemType::Darwin => vec!["sysctl", "-n", "kern.bootsessionuuid"],
+        };
+
+        let boot_id = self.ssh(&command).capture_output().await?;
 
         Ok(BootId(boot_id))
     }

--- a/src/nix/mod.rs
+++ b/src/nix/mod.rs
@@ -48,6 +48,14 @@ pub const SYSTEM_PROFILE: &str = "/nix/var/nix/profiles/system";
 /// Path to the system profile that's currently active.
 pub const CURRENT_PROFILE: &str = "/run/current-system";
 
+/// Default nix bin directory on macOS.
+///
+/// Root's PATH on macOS doesn't include nix binaries by default
+/// (`/usr/bin:/bin:/usr/sbin:/sbin`), and sudo's `secure_path` strips it too.
+/// This is the canonical path that both `/var/root/.nix-profile` and
+/// `/nix/var/nix/profiles/default` symlink to.
+pub const DARWIN_NIX_BIN_PATH: &str = "/nix/var/nix/profiles/default/bin";
+
 /// The type of system a node is running.
 ///
 /// This determines how profiles are validated and activated.
@@ -65,11 +73,6 @@ impl SystemType {
     /// Returns whether this is a darwin system.
     pub fn is_darwin(&self) -> bool {
         matches!(self, SystemType::Darwin)
-    }
-
-    /// Returns whether this is a NixOS system.
-    pub fn is_nixos(&self) -> bool {
-        matches!(self, SystemType::NixOS)
     }
 }
 

--- a/src/nix/mod.rs
+++ b/src/nix/mod.rs
@@ -48,6 +48,40 @@ pub const SYSTEM_PROFILE: &str = "/nix/var/nix/profiles/system";
 /// Path to the system profile that's currently active.
 pub const CURRENT_PROFILE: &str = "/run/current-system";
 
+/// The type of system a node is running.
+///
+/// This determines how profiles are validated and activated.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum SystemType {
+    /// NixOS system using switch-to-configuration for activation.
+    #[default]
+    NixOS,
+    /// macOS system using nix-darwin activation scripts.
+    Darwin,
+}
+
+impl SystemType {
+    /// Returns whether this is a darwin system.
+    pub fn is_darwin(&self) -> bool {
+        matches!(self, SystemType::Darwin)
+    }
+
+    /// Returns whether this is a NixOS system.
+    pub fn is_nixos(&self) -> bool {
+        matches!(self, SystemType::NixOS)
+    }
+}
+
+impl std::fmt::Display for SystemType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            SystemType::NixOS => write!(f, "nixos"),
+            SystemType::Darwin => write!(f, "darwin"),
+        }
+    }
+}
+
 /// A node's attribute name.
 #[derive(Serialize, Deserialize, Clone, Debug, Hash, Eq, PartialEq)]
 #[serde(transparent)]
@@ -83,6 +117,11 @@ pub struct NodeConfig {
 
     #[validate(custom(function = "validate_keys"))]
     keys: HashMap<String, Key>,
+
+    /// The type of system (nixos or darwin).
+    /// Determines how profiles are validated and activated.
+    #[serde(rename = "systemType", default)]
+    system_type: SystemType,
 }
 
 #[derive(Debug, Clone, Validate, Deserialize)]
@@ -181,11 +220,17 @@ impl NodeConfig {
         self.build_on_target = enable;
     }
 
+    /// Returns the system type (NixOS or Darwin).
+    pub fn system_type(&self) -> SystemType {
+        self.system_type
+    }
+
     pub fn to_ssh_host(&self) -> Option<Ssh> {
         self.target_host.as_ref().map(|target_host| {
             let mut host = Ssh::new(self.target_user.clone(), target_host.clone());
             host.set_privilege_escalation_command(self.privilege_escalation_command.clone());
             host.set_extra_ssh_options(self.extra_ssh_options.clone());
+            host.set_system_type(self.system_type);
 
             if let Some(target_port) = self.target_port {
                 host.set_port(target_port);

--- a/src/nix/mod.rs
+++ b/src/nix/mod.rs
@@ -48,6 +48,40 @@ pub const SYSTEM_PROFILE: &str = "/nix/var/nix/profiles/system";
 /// Path to the system profile that's currently active.
 pub const CURRENT_PROFILE: &str = "/run/current-system";
 
+/// The type of system a node is running.
+///
+/// This determines how profiles are validated and activated.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum SystemType {
+    /// NixOS system using switch-to-configuration for activation.
+    #[default]
+    NixOS,
+    /// macOS system using nix-darwin activation scripts.
+    Darwin,
+}
+
+impl SystemType {
+    /// Returns whether this is a darwin system.
+    pub fn is_darwin(&self) -> bool {
+        matches!(self, SystemType::Darwin)
+    }
+
+    /// Returns whether this is a NixOS system.
+    pub fn is_nixos(&self) -> bool {
+        matches!(self, SystemType::NixOS)
+    }
+}
+
+impl std::fmt::Display for SystemType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            SystemType::NixOS => write!(f, "nixos"),
+            SystemType::Darwin => write!(f, "darwin"),
+        }
+    }
+}
+
 /// A node's attribute name.
 #[derive(Serialize, Deserialize, Clone, Debug, Hash, Eq, PartialEq)]
 #[serde(transparent)]
@@ -83,6 +117,11 @@ pub struct NodeConfig {
 
     #[validate(custom(function = "validate_keys"))]
     keys: HashMap<String, Key>,
+
+    /// The type of system (nixos or darwin).
+    /// Determines how profiles are validated and activated.
+    #[serde(rename = "systemType", default)]
+    system_type: SystemType,
 }
 
 #[derive(Debug, Clone, Validate, Deserialize)]
@@ -180,11 +219,17 @@ impl NodeConfig {
         self.build_on_target = enable;
     }
 
+    /// Returns the system type (NixOS or Darwin).
+    pub fn system_type(&self) -> SystemType {
+        self.system_type
+    }
+
     pub fn to_ssh_host(&self) -> Option<Ssh> {
         self.target_host.as_ref().map(|target_host| {
             let mut host = Ssh::new(self.target_user.clone(), target_host.clone());
             host.set_privilege_escalation_command(self.privilege_escalation_command.clone());
             host.set_extra_ssh_options(self.extra_ssh_options.clone());
+            host.set_system_type(self.system_type);
 
             if let Some(target_port) = self.target_port {
                 host.set_port(target_port);

--- a/src/nix/node_filter.rs
+++ b/src/nix/node_filter.rs
@@ -9,6 +9,9 @@ use clap::Args;
 use glob::Pattern as GlobPattern;
 
 use super::{ColmenaError, ColmenaResult, NodeConfig, NodeName};
+// Only referenced by the test NodeConfig template below.
+#[cfg(test)]
+use super::SystemType;
 
 #[derive(Debug, Default, Args)]
 pub struct NodeFilterOpts {
@@ -247,6 +250,7 @@ mod tests {
             privilege_escalation_command: vec![],
             extra_ssh_options: vec![],
             keys: HashMap::new(),
+            system_type: SystemType::default(),
         };
 
         let mut nodes = HashMap::new();

--- a/src/nix/node_filter.rs
+++ b/src/nix/node_filter.rs
@@ -8,7 +8,7 @@ use std::str::FromStr;
 use clap::Args;
 use glob::Pattern as GlobPattern;
 
-use super::{ColmenaError, ColmenaResult, NodeConfig, NodeName};
+use super::{ColmenaError, ColmenaResult, NodeConfig, NodeName, SystemType};
 
 #[derive(Debug, Default, Args)]
 pub struct NodeFilterOpts {
@@ -247,6 +247,7 @@ mod tests {
             privilege_escalation_command: vec![],
             extra_ssh_options: vec![],
             keys: HashMap::new(),
+            system_type: SystemType::default(),
         };
 
         let mut nodes = HashMap::new();

--- a/src/nix/profile.rs
+++ b/src/nix/profile.rs
@@ -4,7 +4,9 @@ use std::process::Stdio;
 
 use tokio::process::Command;
 
-use super::{BuildResult, ColmenaError, ColmenaResult, Goal, StoreDerivation, StorePath, SystemType};
+use super::{
+    BuildResult, ColmenaError, ColmenaResult, Goal, StoreDerivation, StorePath, SystemType,
+};
 
 pub type ProfileDerivation = StoreDerivation<Profile>;
 
@@ -14,7 +16,10 @@ pub struct Profile(StorePath);
 
 impl Profile {
     /// Creates a profile from a store path, validating it against the expected system type.
-    pub fn from_store_path_with_type(path: StorePath, system_type: SystemType) -> ColmenaResult<Self> {
+    pub fn from_store_path_with_type(
+        path: StorePath,
+        system_type: SystemType,
+    ) -> ColmenaResult<Self> {
         if !path.is_dir() {
             return Err(ColmenaError::InvalidProfile);
         }

--- a/src/nix/profile.rs
+++ b/src/nix/profile.rs
@@ -4,17 +4,31 @@ use std::process::Stdio;
 
 use tokio::process::Command;
 
-use super::{BuildResult, ColmenaError, ColmenaResult, Goal, StoreDerivation, StorePath};
+use super::{BuildResult, ColmenaError, ColmenaResult, Goal, StoreDerivation, StorePath, SystemType};
 
 pub type ProfileDerivation = StoreDerivation<Profile>;
 
-/// A NixOS system profile.
+/// A system profile (NixOS or nix-darwin).
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Profile(StorePath);
 
 impl Profile {
-    pub fn from_store_path(path: StorePath) -> ColmenaResult<Self> {
-        if !path.is_dir() || !path.join("bin/switch-to-configuration").exists() {
+    /// Creates a profile from a store path, validating it against the expected system type.
+    pub fn from_store_path_with_type(path: StorePath, system_type: SystemType) -> ColmenaResult<Self> {
+        if !path.is_dir() {
+            return Err(ColmenaError::InvalidProfile);
+        }
+
+        // Validate based on system type
+        let valid = match system_type {
+            SystemType::NixOS => path.join("bin/switch-to-configuration").exists(),
+            SystemType::Darwin => {
+                // nix-darwin profiles have darwin-rebuild at sw/bin/
+                path.join("sw/bin/darwin-rebuild").exists()
+            }
+        };
+
+        if !valid {
             return Err(ColmenaError::InvalidProfile);
         }
 
@@ -25,18 +39,54 @@ impl Profile {
         }
     }
 
-    /// Returns the command to activate this profile.
-    pub fn activation_command(&self, goal: Goal) -> Option<Vec<String>> {
-        if let Some(goal) = goal.as_str() {
+    /// Returns the command to activate this profile for NixOS.
+    pub fn activation_command_nixos(&self, goal: Goal) -> Option<Vec<String>> {
+        if let Some(goal_str) = goal.as_str() {
             let path = self.as_path().join("bin/switch-to-configuration");
             let switch_to_configuration = path
                 .to_str()
                 .expect("The string should be UTF-8 valid")
                 .to_string();
 
-            Some(vec![switch_to_configuration, goal.to_string()])
+            Some(vec![switch_to_configuration, goal_str.to_string()])
         } else {
             None
+        }
+    }
+
+    /// Returns the command to activate this profile for Darwin.
+    ///
+    /// Uses darwin-rebuild at sw/bin/darwin-rebuild to activate the configuration.
+    /// Note: Darwin doesn't support the "boot" goal (no boot profiles).
+    pub fn activation_command_darwin(&self, goal: Goal) -> Option<Vec<String>> {
+        let darwin_rebuild_path = self.as_path().join("sw/bin/darwin-rebuild");
+        let darwin_rebuild = darwin_rebuild_path
+            .to_str()
+            .expect("The string should be UTF-8 valid")
+            .to_string();
+
+        match goal {
+            Goal::Switch | Goal::Test => {
+                // darwin-rebuild activate applies the configuration
+                Some(vec![darwin_rebuild, "activate".to_string()])
+            }
+            Goal::DryActivate => {
+                // darwin-rebuild check validates without applying
+                Some(vec![darwin_rebuild, "check".to_string()])
+            }
+            Goal::Boot => {
+                // Darwin doesn't have boot profiles - this goal is not supported
+                None
+            }
+            _ => None,
+        }
+    }
+
+    /// Returns the command to activate this profile based on system type.
+    pub fn activation_command(&self, goal: Goal, system_type: SystemType) -> Option<Vec<String>> {
+        match system_type {
+            SystemType::NixOS => self.activation_command_nixos(goal),
+            SystemType::Darwin => self.activation_command_darwin(goal),
         }
     }
 

--- a/src/nix/profile.rs
+++ b/src/nix/profile.rs
@@ -15,37 +15,8 @@ pub type ProfileDerivation = StoreDerivation<Profile>;
 pub struct Profile(StorePath);
 
 impl Profile {
-    /// Creates a profile from a store path, validating it against the expected system type.
-    pub fn from_store_path_with_type(
-        path: StorePath,
-        system_type: SystemType,
-    ) -> ColmenaResult<Self> {
-        if !path.is_dir() {
-            return Err(ColmenaError::InvalidProfile);
-        }
-
-        // Validate based on system type
-        let valid = match system_type {
-            SystemType::NixOS => path.join("bin/switch-to-configuration").exists(),
-            SystemType::Darwin => {
-                // nix-darwin profiles have darwin-rebuild at sw/bin/
-                path.join("sw/bin/darwin-rebuild").exists()
-            }
-        };
-
-        if !valid {
-            return Err(ColmenaError::InvalidProfile);
-        }
-
-        if path.to_str().is_none() {
-            Err(ColmenaError::InvalidProfile)
-        } else {
-            Ok(Self(path))
-        }
-    }
-
     /// Returns the command to activate this profile for NixOS.
-    pub fn activation_command_nixos(&self, goal: Goal) -> Option<Vec<String>> {
+    fn activation_command_nixos(&self, goal: Goal) -> Option<Vec<String>> {
         if let Some(goal_str) = goal.as_str() {
             let path = self.as_path().join("bin/switch-to-configuration");
             let switch_to_configuration = path
@@ -61,9 +32,10 @@ impl Profile {
 
     /// Returns the command to activate this profile for Darwin.
     ///
-    /// Uses darwin-rebuild at sw/bin/darwin-rebuild to activate the configuration.
-    /// Note: Darwin doesn't support the "boot" goal (no boot profiles).
-    pub fn activation_command_darwin(&self, goal: Goal) -> Option<Vec<String>> {
+    /// Uses `sw/bin/darwin-rebuild` to activate the configuration. Darwin has no
+    /// separate boot profile, so the `Boot` goal is unsupported (returns `None`,
+    /// via the catch-all — callers gate on [`Goal::supported_on_darwin`]).
+    fn activation_command_darwin(&self, goal: Goal) -> Option<Vec<String>> {
         let darwin_rebuild_path = self.as_path().join("sw/bin/darwin-rebuild");
         let darwin_rebuild = darwin_rebuild_path
             .to_str()
@@ -71,18 +43,10 @@ impl Profile {
             .to_string();
 
         match goal {
-            Goal::Switch | Goal::Test => {
-                // darwin-rebuild activate applies the configuration
-                Some(vec![darwin_rebuild, "activate".to_string()])
-            }
-            Goal::DryActivate => {
-                // darwin-rebuild check validates without applying
-                Some(vec![darwin_rebuild, "check".to_string()])
-            }
-            Goal::Boot => {
-                // Darwin doesn't have boot profiles - this goal is not supported
-                None
-            }
+            // `darwin-rebuild activate` applies the configuration.
+            Goal::Switch | Goal::Test => Some(vec![darwin_rebuild, "activate".to_string()]),
+            // `darwin-rebuild check` validates without applying.
+            Goal::DryActivate => Some(vec![darwin_rebuild, "check".to_string()]),
             _ => None,
         }
     }


### PR DESCRIPTION
Add support for deploying to macOS machines using nix-darwin, alongside the
existing NixOS support.

## Capabilities

- `SystemType` (NixOS vs Darwin), threaded through evaluation, build, copy, and
  activation.
- `evalDarwinNode` in `eval.nix` evaluates darwin nodes via nix-darwin's
  `darwinSystem`; `meta.nix-darwin` supplies the input.
- Node system type is resolved from an explicit `deployment.systemType`, or
  auto-detected from a flake's `darwinConfigurations`.
- Darwin-specific profile activation (`sw/bin/darwin-rebuild activate`), with the
  `boot` goal correctly reported as unsupported on darwin.
- `darwinDefaults` for darwin-only defaults.
- `colmena apply-local` and `buildOnTarget` work on macOS, including when
  connecting as root.
- Handles macOS specifics where root's PATH (and sudo's `secure_path`) lack the
  nix binaries: absolute nix paths for local/remote commands, `remote-program`
  on the ssh-ng store, and `nix copy` (rather than legacy `nix-copy-closure`)
  for darwin targets.

## Credits

The `apply-local`/root `buildOnTarget` enablement and the initial darwin test
coverage are by @sini, preserved as their own commits. Thanks!

## Usage (flake)

```nix
{
  inputs.nix-darwin.url = "github:LnL7/nix-darwin";

  outputs = { nixpkgs, nix-darwin, ... }: {
    colmena = {
      meta = {
        nixpkgs = import nixpkgs { system = "aarch64-darwin"; };
        nix-darwin = nix-darwin;          # required for darwin nodes
      };

      my-mac = {
        deployment.systemType = "darwin"; # or auto-detected via darwinConfigurations
        deployment.targetHost = "my-mac.local";
        # ... darwin configuration ...
      };
    };
  };
}
```

## Notes

- Darwin nodes require `meta.nix-darwin` to be set.
- Non-flake darwin deployments use `nix copy` for closure transfer (the legacy
  `nix-copy-closure` path cannot target nix on a macOS host without a PATH on the
  remote); flake deployments already used this path.
