### PR TITLE
Use error on invalid UTF-8 output

### DIFF
--- a/src/util.rs
+++ b/src/util.rs
@@ -132,8 +132,9 @@ impl CommandExt for Command {
             .await?;
 
         if output.status.success() {
-            // FIXME: unwrap
-            Ok(String::from_utf8(output.stdout).unwrap())
+            String::from_utf8(output.stdout).map_err(|err| ColmenaError::BadOutput {
+                output: String::from_utf8_lossy(err.as_bytes()).to_string(),
+            })
         } else {
             Err(output.status.into())
         }


### PR DESCRIPTION
This update returns ColmenaError::BadOutput instead of unwrapping when capturing a command’s output. I used from_utf8_lossy to keep the output readable with replacement characters for invalid sequences, avoiding a panic on non-UTF-8 bytes.