### PR TITLE
Use error in missing output

### DIFF
--- a/src/util.rs
+++ b/src/util.rs
@@ -169,7 +169,9 @@ impl CommandExt for CommandExecution {
         self.run().await?;
         let (stdout, _) = self.get_logs();
 
-        Ok(stdout.unwrap().to_owned())
+        stdout.cloned().ok_or_else(|| ColmenaError::BadOutput {
+            output: "missing stdout from command".into(),
+        })
     }
 
     /// Captures deserialized output from JSON.


### PR DESCRIPTION
This update returns ColmenaError::BadOutput instead of unwrapping when capturing a command’s output in CommandExecution.